### PR TITLE
Prevent use of dynamic ``__import__``

### DIFF
--- a/astrodendro/dendrogram.py
+++ b/astrodendro/dendrogram.py
@@ -42,6 +42,7 @@ IO_FORMATS = {
 
 # Define main dendrogram class
 
+
 class Dendrogram(object):
 
     def __init__(self):
@@ -233,14 +234,14 @@ class Dendrogram(object):
     @staticmethod
     def load_from(filename, format="autodetect"):
         if format == "autodetect":
-            format = filename.rsplit('.',1)[-1].lower()
+            format = filename.rsplit('.', 1)[-1].lower()
         return IO_FORMATS[format][1](filename)
-    
+
     def save_to(self, filename, format="autodetect"):
         if format == "autodetect":
-            format = filename.rsplit('.',1)[-1].lower()
+            format = filename.rsplit('.', 1)[-1].lower()
         return IO_FORMATS[format][0](self, filename)
-    
+
     @property
     def all_nodes(self):
         " Return a flattened iterable containing all nodes in the dendrogram "

--- a/astrodendro/io/fits.py
+++ b/astrodendro/io/fits.py
@@ -23,13 +23,15 @@ import numpy as np
 
 # Import and export
 
+
 def dendro_export_fits(d, filename):
-    " Export the dendrogram 'd' to the FITS file 'filename' "
+    """Export the dendrogram 'd' to the FITS file 'filename'"""
     import pyfits
     raise NotImplementedError("FITS export has not yet been implemented.")
 
+
 def dendro_import_fits(filename):
-    " Import 'filename' and construct a dendrogram from it "
+    """Import 'filename' and construct a dendrogram from it"""
     import pyfits
     from ..dendrogram import Dendrogram
     from ..components import Leaf, Branch

--- a/astrodendro/io/hdf5.py
+++ b/astrodendro/io/hdf5.py
@@ -88,6 +88,7 @@ def _parse_newick(string):
 
 # Import and export
 
+
 def dendro_export_hdf5(d, filename):
     """Export the dendrogram 'd' to the HDF5 file 'filename'"""
     import h5py
@@ -108,6 +109,7 @@ def dendro_export_hdf5(d, filename):
     ds.attrs['IMAGE_MINMAXRANGE'] = [d.data.min(), d.data.max()]
 
     f.close()
+
 
 def dendro_import_hdf5(filename):
     """Import 'filename' and construct a dendrogram from it"""


### PR DESCRIPTION
I would prefer if we didn't use `__import__` because it feels a bit hacky, and is not relative-import friendly. What do you think about the following way? It does mean adding an entry to the main `dendrogram.py` file when a new file format is added, but I don't think it will happen very often.

This means moving the `h5py` and `pyfits` imports inside the functions to prevent `ImportErrors` if the dependencies are not installed, and also involves moving the imports of `Dendrogram`, `Branch`, and `Leaf` inside the import method to prevent circular imports.

cc @bradenmacdonald @ChrisBeaumont
