### PR TITLE
update signature of static warning

### DIFF
--- a/astrodendro/dendrogram.py
+++ b/astrodendro/dendrogram.py
@@ -37,7 +37,7 @@ class Dendrogram(object):
         # Put in a friendly error message to make sure nobody confuses the
         # static methods for creating a dendrogram with instance methods:
 
-        def static_warning(self):
+        def static_warning(self, *args, **kwargs):
             err = "Invalid use of static method. Try d=Dendrogram.compute(data)"
             err += " or d=Dendrogram.load_from(file)"
             raise AttributeError(err)


### PR DESCRIPTION
The static_warning method doesn't give it's helpful error message if keyword parameters are supplied:

```
In [1]: from astrodendro.dendrogram import Dendrogram
In [2]: d = Dendrogram()
In [3]: d.compute('test.fits', min_flux=2)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-2f4ec08a4ef3> in <module>()
----> 1 d.compute('test.fits', min_flux=2)

TypeError: static_warning() got an unexpected keyword argument 'min_flux'
```

This PR makes sure the static warning message is always displayed
