### PR TITLE
Added source file for diagrams

### DIFF
--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -1,0 +1,2 @@
+The diagrams in this directory were created with InkScape, which can be 
+freely downloaded from [http://inkscape.org/](http://inkscape.org/).

--- a/docs/diagrams/dendrograms.svg
+++ b/docs/diagrams/dendrograms.svg
@@ -1,0 +1,879 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="1052.3622"
+   height="744.09448"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.2 r9819"
+   sodipodi:docname="dendrogram.svg"
+   inkscape:export-filename="/Volumes/Macintosh HD/Users/tom/Dropbox/Code/development/dendrograms/dendrograms.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.75"
+     inkscape:cx="350"
+     inkscape:cy="279.54566"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1717"
+     inkscape:window-height="1057"
+     inkscape:window-x="49"
+     inkscape:window-y="22"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-308.2677)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path4089"
+       d="m 814.91011,403.54502 c -3.96282,-0.42439 -8.46355,-2.73572 -11.73722,-6.02758 -2.36962,-2.3828 -3.64421,-4.66574 -3.81169,-6.8272 -0.10594,-1.36717 0.35886,-2.62921 1.54838,-4.20419 2.61917,-3.46794 8.7233,-7.17422 13.50013,-8.19697 3.1693,-0.67856 6.41886,0.55729 9.42308,3.5837 2.10424,2.1198 3.71927,5.04091 4.2054,7.60629 0.17711,0.93466 0.1523,2.76419 -0.0499,3.67984 -0.85318,3.86355 -3.18518,7.1957 -6.31525,9.02376 -1.93058,1.12752 -4.36898,1.61872 -6.76292,1.36235 z"
+       style="fill:#d45500;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4097"
+       d="m 962.98602,499.85755 c -4.26949,-0.99015 -10.25505,-5.90168 -12.29382,-10.08785 -0.6275,-1.28841 -0.84689,-2.13843 -0.84489,-3.27333 0.004,-2.15392 1.24193,-4.8531 3.28702,-7.16595 0.45726,-0.51713 1.50999,-1.54049 2.06646,-2.00882 1.81624,-1.52854 4.32671,-2.80374 6.31076,-3.20554 1.36093,-0.27562 1.83254,-0.28388 3.42079,-0.0599 3.59419,0.50682 6.11126,1.47279 7.88431,3.02576 2.07263,1.81538 3.12079,4.52199 3.12054,8.05795 -1.3e-4,1.48755 -0.21717,2.6933 -0.75376,4.18751 -1.39513,3.88489 -4.7236,7.88881 -8.12787,9.77726 -1.51728,0.84167 -2.72407,1.06495 -4.06954,0.75293 z"
+       style="fill:#ffb380;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       sodipodi:nodetypes="csssc"
+       inkscape:connector-curvature="0"
+       id="path4099"
+       d="m 963.56223,473.75286 c -6.3862,0 -13.41172,6.72817 -13.86007,12.38559 -0.4661,5.88131 9.56799,13.79896 14.30239,14.00752 4.2648,0.18787 12.17542,-7.7667 12.09071,-15.03965 -0.10218,-8.77185 -6.19841,-10.71046 -12.53303,-11.35346 z"
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       sodipodi:nodetypes="csssc"
+       inkscape:connector-curvature="0"
+       id="path4091"
+       d="m 816.38927,377.8605 c -5.53545,0 -16.60636,6.56055 -17.22141,11.89098 -0.61506,5.33045 7.58562,12.91607 15.37626,13.94115 7.79064,1.02509 12.71105,-5.12542 13.73614,-11.07091 1.02508,-5.94549 -5.12543,-14.35118 -11.89099,-14.76122 z"
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4085"
+       d="m 626.03191,389.02875 c -2.38644,-0.62555 -4.89802,-2.21891 -7.36994,-4.67553 -2.98621,-2.96772 -4.74014,-5.86625 -5.31937,-8.79076 -0.21166,-1.06864 0.029,-2.59941 0.60229,-3.83131 0.88776,-1.9076 3.01542,-4.1824 5.27979,-5.64493 3.70277,-2.39157 8.24687,-3.51424 11.14941,-2.75458 3.044,0.79667 7.53769,4.38846 10.20153,8.15403 2.60594,3.68371 3.05285,6.14451 1.61598,8.89782 -2.27205,4.35363 -9.12299,8.64222 -14.12775,8.84376 -0.94041,0.0379 -1.2429,0.008 -2.03194,-0.1985 l 0,0 z"
+       style="fill:#d45500"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       sodipodi:nodetypes="csssc"
+       inkscape:connector-curvature="0"
+       id="path4087"
+       d="m 628.96079,362.931 c -6.62937,-0.40178 -15.46855,5.42404 -15.87033,11.24986 -0.40178,5.82582 8.83918,15.66944 15.06677,15.26766 6.22761,-0.40178 15.06678,-6.62938 15.06678,-12.05342 0,-5.42404 -9.24096,-14.4641 -14.26322,-14.4641 z"
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:#ffb380"
+       d="m 423.3794,589.05079 c -14.47797,-3.35762 -34.77526,-20.0128 -41.6888,-34.20824 -2.12786,-4.36907 -2.87184,-7.2515 -2.86504,-11.1 0.0129,-7.30402 4.21141,-16.45705 11.1464,-24.3 1.55059,-1.7536 5.12043,-5.22386 7.00744,-6.81197 6.15894,-5.18336 14.67204,-9.5076 21.4,-10.87013 4.61498,-0.93462 6.2142,-0.96263 11.6,-0.20318 12.18815,1.71866 20.72362,4.9943 26.73606,10.26047 7.0284,6.15602 10.58278,15.33422 10.58186,27.32481 -4e-4,5.04434 -0.73635,9.13307 -2.55598,14.2 -4.73097,13.17381 -16.01793,26.75122 -27.56194,33.15502 -5.14514,2.85417 -9.23749,3.61132 -13.8,2.55322 z"
+       id="path3096"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="/Users/tom/schematic_structure.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:#d45500"
+       d="m 255.72592,539.16883 c -9.66463,-1.03501 -20.64112,-6.67193 -28.625,-14.7002 -5.77909,-5.81123 -8.88758,-11.37892 -9.29605,-16.65035 -0.25836,-3.33427 0.87521,-6.41216 3.77622,-10.25327 6.3877,-8.45767 21.2746,-17.49665 32.92444,-19.99094 7.72936,-1.6549 15.65447,1.35911 22.98122,8.74001 5.13187,5.1698 9.07065,12.29387 10.25622,18.5504 0.43195,2.27946 0.37144,6.74136 -0.1217,8.97447 -2.08076,9.42251 -7.76809,17.54904 -15.40177,22.00735 -4.70835,2.74983 -10.65518,3.94778 -16.49358,3.32253 z"
+       id="path3090"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="/Users/tom/schematic_structure.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:#ffe6d5"
+       d="m 372.36722,638.81294 c -14.78107,-0.82707 -28.78041,-4.38288 -40.75,-10.35044 -1.925,-0.95973 -6.875,-3.66338 -11,-6.0081 -29.86093,-16.97349 -58.28955,-26.81443 -87,-30.11619 -14.75473,-1.69683 -51.11301,-1.55859 -75.25,0.2861 -5.3625,0.40984 -15.6,1.18766 -22.75,1.7285 -25.66235,1.94114 -42.745966,0.9894 -55.250006,-3.07802 -10.83703,-3.52516 -19.23548,-10.97833 -22.97977,-20.3933 -0.50067,-1.25891 -2.06032,-5.08688 -3.46589,-8.50659 -4.10779,-9.99409 -7.09254,-21.62661 -8.60396,-33.53235 -0.89002,-7.01079 -0.73673,-22.55069 0.29346,-29.75 3.53774,-24.72297 14.50953,-46.48012 33.23206,-65.89942 15.58368,-16.16364 32.855676,-26.14724 54.130406,-31.28859 11.96037,-2.8904 16.4616,-3.31446 34.8937,-3.28737 14.35147,0.0211 17.96059,0.18392 25.20408,1.13709 32.64044,4.29514 60.54997,11.32769 127.29592,32.07562 52.80839,16.41545 74.04142,22.74586 105.75,31.5283 36.7641,10.18268 44.94113,13.07738 64.29562,22.76093 11.03672,5.52196 17.83931,11.16505 23.54669,19.53316 11.98292,17.56925 14.86589,44.15891 7.13556,65.81135 -3.20016,8.96356 -7.43327,14.6158 -15.47787,20.66672 -33.97151,25.55243 -81.21807,44.55795 -115.5,46.46133 -2.75,0.15269 -6.35,0.34991 -8,0.43829 -1.65,0.0884 -6.0375,-0.009 -9.75,-0.21702 l 0,0 z m 59.54972,-49.17923 c 6.01581,-1.82593 12.50622,-6.35321 19.26543,-13.43828 12.19214,-12.77993 18.13109,-27.65582 16.66927,-41.7532 -1.48728,-14.34278 -7.12764,-22.87513 -18.79397,-28.4302 -7.52828,-3.58469 -18.94926,-5.96522 -26.44045,-5.51111 -23.23075,1.40822 -48.86483,29.56023 -44.01793,48.34163 1.90143,7.36792 6.4537,14.30962 14.75521,22.5 6.47479,6.38812 12.95647,11.10042 20.26272,14.73135 8.28371,4.1167 13.26955,5.08658 18.29972,3.55981 l 0,0 z M 265.36722,577.06234 c 29.94496,-5.25817 52.7474,-24.98605 60.64713,-52.46979 2.69906,-9.3902 3.07315,-12.27829 3.07631,-23.75 0.003,-10.38176 -0.0415,-10.86546 -1.29665,-14.12077 -3.67377,-9.52864 -10.7226,-16.54356 -22.92679,-22.8165 -19.62778,-10.08867 -50.94785,-16.79038 -96,-20.54159 -18.25815,-1.52024 -41.87189,-3.02114 -47.53179,-3.02114 -22.33777,0 -43.17202,8.13 -57.85517,22.57641 -5.406996,5.31981 -7.948826,8.90797 -11.325096,15.98703 -7.59062,15.91529 -9.16621,27.13152 -5.12312,36.47012 1.3143,3.03572 5.33602,7.937 9.29738,11.33075 7.834306,6.71173 13.189126,10.03546 27.219956,16.89539 43.81696,21.4229 74.03873,30.39442 115.31784,34.2328 6.74887,0.62755 20.87065,0.21578 26.5,-0.77271 l 0,0 z"
+       id="path3094"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="/Users/tom/schematic_structure.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:#ffb380"
+       d="m 245.85092,577.43956 c -0.6875,-0.0554 -3.6125,-0.27384 -6.5,-0.48553 -30.41608,-2.22988 -60.6845,-9.77916 -90.875,-22.66522 -8.55513,-3.65154 -22.3957,-10.13285 -33.125,-15.51187 -9.05944,-4.54186 -20.399236,-13.35757 -24.837986,-19.30939 -1.72598,-2.31433 -3.67456,-6.27594 -4.28769,-8.71719 -1.64671,-6.5566 -0.30315,-14.88597 4.19918,-26.03281 3.86735,-9.57473 6.63283,-14.08552 12.169516,-19.84973 9.06547,-9.43803 21.33455,-16.63856 34.94171,-20.50671 7.62194,-2.16672 13.54707,-3.02373 22.06527,-3.19152 5.55309,-0.10939 7.90864,-0.009 21.125,0.90448 49.26861,3.40357 72.26921,6.36099 95.375,12.26335 20.90127,5.33921 35.04356,12.22187 43.75,21.29191 7.04078,7.33482 9.21532,14.16203 8.78716,27.58822 -0.16995,5.32942 -0.63071,9.51064 -1.55653,14.125 -5.3322,26.57603 -23.36692,47.06744 -49.10563,55.7948 -8.1357,2.75861 -16.43395,4.15525 -25.625,4.31284 -2.8875,0.0495 -5.8125,0.0447 -6.5,-0.0106 l 0,0 z m 18.27351,-37.73923 c 5.79536,-1.02901 10.70046,-3.71828 15.1542,-8.30845 7.12169,-7.33986 10.90404,-18.13264 9.3063,-26.5552 -2.06552,-10.88855 -10.47883,-21.74251 -20.42663,-26.35227 -6.55167,-3.03601 -11.53352,-3.03145 -20.05738,0.0184 -13.37323,4.78493 -26.54222,15.0416 -30.28794,23.58976 -0.6629,1.51281 -0.71206,1.84939 -0.71206,4.875 0,3.74494 0.38415,5.2315 2.29076,8.86469 1.69283,3.22582 3.66261,5.81412 6.95924,9.14451 7.80977,7.88973 17.93224,13.3071 27.75,14.85132 3.23635,0.50903 6.68469,0.46509 10.02351,-0.12774 l 0,0 z M 158.47592,527.44321 c 12.17222,-2.12277 26.96484,-12.26934 32.03939,-21.97651 2.63694,-5.04424 2.84318,-9.36167 0.70501,-14.75856 -3.95188,-9.97483 -15.68141,-22.20103 -26.1194,-27.22541 -4.16639,-2.00551 -5.27965,-2.25641 -10,-2.25366 -6.0775,0.004 -11.18091,1.27165 -17.51902,4.35317 -8.00059,3.8898 -15.48672,10.63188 -18.60465,16.75552 -1.74695,3.43102 -2.42051,7.83328 -1.7457,11.40963 2.57784,13.66203 20.22169,31.54901 33.36937,33.82919 0.825,0.14308 1.78125,0.30618 2.125,0.36244 0.8796,0.14398 3.25671,-0.061 5.75,-0.49581 z"
+       id="path3084"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="/Users/tom/schematic_structure.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:#d45500"
+       d="m 149.54357,526.48406 c -5.93966,-1.55694 -12.1908,-5.52269 -18.3432,-11.63701 -7.43244,-7.38643 -11.79783,-14.60065 -13.23947,-21.8795 -0.5268,-2.65976 0.0721,-6.46973 1.49904,-9.53583 2.20957,-4.74786 7.50513,-10.40966 13.14098,-14.04978 9.21591,-5.95244 20.5258,-8.74668 27.75,-6.85595 7.57626,1.98287 18.7607,10.92254 25.3908,20.29474 6.48597,9.16846 7.59831,15.2932 4.02203,22.14597 -5.65494,10.83584 -22.70639,21.50981 -35.16283,22.01143 -2.34061,0.0943 -3.09349,0.0207 -5.05735,-0.49407 l 0,0 z"
+       id="path3080"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="/Users/tom/schematic_structure.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 56.333334,569.02884 c 0,0 -38,-71 20,-134 58.000006,-63 144.000006,-35 262.000006,2 118,37 113,29 155,50 42,21 38,83 18,101 -20,18 -117,79 -187,37 -70,-42 -119.11116,-32.78097 -147,-33 -36.99886,-0.29058 -108.000006,18 -121.000006,-23 z"
+       id="path2989"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cssssssc"
+       inkscape:export-filename="/Users/tom/schematic_structure.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 93.647034,476.37199 c -16.68613,34.57024 -7.97718,43.57949 16.878686,60.48528 32.26346,16.02082 73.888,37.58871 134.69849,40.99137 49.23076,2.75473 87.36456,-32.78768 83.69848,-83.89949 -3.35405,-46.76152 -114.92695,-49.67702 -161.20458,-53.19239 -41.27476,-2.53896 -67.37802,21.50481 -74.071076,35.61523 z"
+       id="path2991"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccsscc"
+       inkscape:export-filename="/Users/tom/schematic_structure.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 425.33334,500.52884 c -21.65583,0 -45.47961,22.81545 -47,42 -1.58055,19.94372 32.44541,46.79278 48.5,47.5 14.46208,0.63707 41.2873,-26.33716 41,-51 -0.34651,-29.74569 -21.01902,-36.31957 -42.5,-38.5 z"
+       id="path3021"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssc"
+       inkscape:export-filename="/Users/tom/schematic_structure.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 259.33334,476.52884 c -13.5,0 -40.5,16 -42,29 -1.5,13 18.5,31.5 37.5,34 19,2.5 31,-12.5 33.5,-27 2.5,-14.5 -12.5,-35 -29,-36 z"
+       id="path3025"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssc"
+       inkscape:export-filename="/Users/tom/schematic_structure.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 843.88395,665.81245 0,-90.92302"
+       id="path3046"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 724.35419,574.88943 240.63592,0"
+       id="path3048"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 156.83334,461.52884 c -16.5,-1 -38.5,13.5 -39.5,28 -1,14.5 22,39 37.5,38 15.5,-1 37.5,-16.5 37.5,-30 0,-13.5 -23,-36 -35.5,-36 z"
+       id="path3023"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssc"
+       inkscape:export-filename="/Users/tom/schematic_structure.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path3888"
+       d="m 725.48165,576.13287 0,-90.92302"
+       style="fill:none;stroke:#000000;stroke-width:2.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 963.66761,574.87636 0,-68.4937"
+       id="path3890"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path3892"
+       d="m 625.29868,485.77778 190.04292,0"
+       style="fill:none;stroke:#000000;stroke-width:2.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       inkscape:transform-center-y="-2.1755755"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:#ff9955;stroke:#000000;stroke-width:2.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 814.30815,486.78916 0,-75.32001"
+       id="path3894"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path3896"
+       d="m 626.53211,487.009 0,-90.92302"
+       style="fill:#ff9955;stroke:#000000;stroke-width:2.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="318.33331"
+       y="606.02881"
+       id="text3898"
+       sodipodi:linespacing="125%"
+       inkscape:export-filename="/Users/tom/schematic_structure.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90"><tspan
+         sodipodi:role="line"
+         id="tspan3900"
+         x="318.33331"
+         y="606.02881"
+         style="font-size:18px;font-family:helvetica;-inkscape-font-specification:helvetica">trunk</tspan></text>
+    <text
+       sodipodi:linespacing="125%"
+       id="text3936"
+       y="555.02881"
+       x="169.33334"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       xml:space="preserve"
+       inkscape:export-filename="/Users/tom/schematic_structure.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90"><tspan
+         style="font-size:18px;font-family:helvetica;-inkscape-font-specification:helvetica"
+         y="555.02881"
+         x="169.33334"
+         id="tspan3938"
+         sodipodi:role="line">branch</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="227.33334"
+       y="513.02881"
+       id="text3944"
+       sodipodi:linespacing="125%"
+       inkscape:export-filename="/Users/tom/schematic_structure.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90"><tspan
+         sodipodi:role="line"
+         id="tspan3946"
+         x="227.33334"
+         y="513.02881"
+         style="font-size:18px;font-family:helvetica;-inkscape-font-specification:helvetica">leaf 2</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="127.33334"
+       y="500.02884"
+       id="text3948"
+       sodipodi:linespacing="125%"
+       inkscape:export-filename="/Users/tom/schematic_structure.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90"><tspan
+         sodipodi:role="line"
+         id="tspan3950"
+         x="127.33334"
+         y="500.02884"
+         style="font-size:18px;font-family:helvetica;-inkscape-font-specification:helvetica">leaf 1</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="430"
+       y="107.09448"
+       id="text3952"
+       sodipodi:linespacing="125%"
+       transform="translate(0,308.2677)"><tspan
+         sodipodi:role="line"
+         id="tspan3954"
+         x="430"
+         y="107.09448" /></text>
+    <text
+       sodipodi:linespacing="125%"
+       id="text3956"
+       y="550.02881"
+       x="398.33331"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       xml:space="preserve"
+       inkscape:export-filename="/Users/tom/schematic_structure.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90"><tspan
+         style="font-size:18px;font-family:helvetica;-inkscape-font-specification:helvetica"
+         y="550.02881"
+         x="398.33331"
+         id="tspan3958"
+         sodipodi:role="line">leaf 3</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="575.16669"
+       y="535.6955"
+       id="text3964"
+       sodipodi:linespacing="125%"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90"><tspan
+         sodipodi:role="line"
+         id="tspan3966"
+         x="575.16669"
+         y="535.6955"
+         style="font-size:16px;font-family:helvetica;-inkscape-font-specification:helvetica">branch</tspan></text>
+    <text
+       sodipodi:linespacing="125%"
+       id="text3968"
+       y="381.69553"
+       x="562.66669"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       xml:space="preserve"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90"><tspan
+         style="font-size:16px;font-family:helvetica;-inkscape-font-specification:helvetica"
+         y="381.69553"
+         x="562.66669"
+         id="tspan3970"
+         sodipodi:role="line">leaf 1</tspan></text>
+    <text
+       sodipodi:linespacing="125%"
+       id="text3972"
+       y="397.69553"
+       x="747.16669"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       xml:space="preserve"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90"><tspan
+         style="font-size:16px;font-family:helvetica;-inkscape-font-specification:helvetica"
+         y="397.69553"
+         x="747.16669"
+         id="tspan3974"
+         sodipodi:role="line">leaf 2</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="895.66669"
+       y="492.19553"
+       id="text3976"
+       sodipodi:linespacing="125%"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90"><tspan
+         sodipodi:role="line"
+         id="tspan3978"
+         x="895.66669"
+         y="492.19553"
+         style="font-size:16px;font-family:helvetica;-inkscape-font-specification:helvetica">leaf 3</tspan></text>
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       inkscape:connector-curvature="0"
+       id="path3059"
+       d="m 930.28377,636.55843 c -2.8722,-0.66611 -6.8989,-3.97025 -8.2704,-6.78642 -0.4222,-0.86676 -0.5698,-1.43859 -0.5684,-2.20208 0,-1.44901 0.8355,-3.26484 2.2113,-4.82077 0.3076,-0.34788 1.0158,-1.03633 1.3902,-1.35139 1.2218,-1.0283 2.9107,-1.88617 4.2454,-2.15648 0.9155,-0.18541 1.2328,-0.19097 2.3013,-0.0403 2.4179,0.34095 4.1112,0.99079 5.304,2.03552 1.3943,1.22127 2.0995,3.04209 2.0993,5.42085 -1e-4,1.00072 -0.1461,1.81187 -0.5071,2.81707 -0.9385,2.61349 -3.1777,5.30705 -5.4679,6.57747 -1.0207,0.56623 -1.8325,0.71644 -2.7377,0.50653 z"
+       style="fill:#ffb380" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       inkscape:connector-curvature="0"
+       id="path3061"
+       d="m 897.02377,626.66257 c -1.91731,-0.20533 -4.09488,-1.32361 -5.67877,-2.9163 -1.14649,-1.15287 -1.76317,-2.25742 -1.8442,-3.30319 -0.0513,-0.66147 0.17363,-1.27208 0.74915,-2.0341 1.26722,-1.67788 4.22057,-3.47108 6.53172,-3.96591 1.5334,-0.32831 3.1056,0.26963 4.5591,1.73389 1.0181,1.02561 1.7995,2.43892 2.0347,3.68013 0.086,0.45221 0.074,1.33739 -0.024,1.7804 -0.4128,1.86929 -1.5411,3.48148 -3.0555,4.36594 -0.934,0.54553 -2.1138,0.78318 -3.2721,0.65914 z"
+       style="fill:#d45500" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       inkscape:connector-curvature="0"
+       id="path3063"
+       d="m 920.16367,646.43051 c -2.9323,-0.16408 -5.7096,-0.8695 -8.0842,-2.05338 -0.3819,-0.19039 -1.3639,-0.72676 -2.1822,-1.19191 -5.924,-3.3673 -11.5638,-5.3196 -17.25953,-5.97462 -2.92712,-0.33662 -10.14008,-0.3092 -14.9285,0.0568 -1.06385,0.0813 -3.09482,0.23561 -4.51327,0.34291 -5.09104,0.38509 -8.48018,0.19628 -10.9608,-0.61064 -2.14991,-0.69934 -3.81604,-2.17794 -4.55885,-4.04573 -0.0993,-0.24975 -0.40874,-1.00916 -0.68758,-1.68758 -0.81493,-1.98268 -1.40706,-4.29041 -1.7069,-6.65233 -0.17657,-1.39084 -0.14616,-4.47373 0.0582,-5.90197 0.70183,-4.90468 2.87848,-9.22098 6.59275,-13.07348 3.09158,-3.20664 6.51809,-5.18724 10.73869,-6.2072 2.37276,-0.57342 3.26574,-0.65755 6.9224,-0.65217 2.84712,0.004 3.56312,0.0365 5.00012,0.22558 6.47539,0.85209 12.01223,2.24725 25.25367,6.36334 10.4764,3.25658 14.6887,4.51244 20.9793,6.25475 7.2934,2.0201 8.9156,2.59436 12.7553,4.51544 2.1895,1.09548 3.539,2.21498 4.6713,3.87509 2.3772,3.48549 2.9492,8.76049 1.4156,13.05602 -0.6349,1.77824 -1.4747,2.89956 -3.0706,4.09997 -6.7395,5.06923 -16.1125,8.83965 -22.9135,9.21725 -0.5456,0.0303 -1.2598,0.0694 -1.5871,0.087 -0.3273,0.0175 -1.1978,-0.002 -1.9343,-0.0431 l 0,0 z m 11.8138,-9.75644 c 1.1935,-0.36224 2.4811,-1.26039 3.822,-2.66596 2.4188,-2.53535 3.597,-5.48651 3.307,-8.28323 -0.2951,-2.8454 -1.414,-4.53809 -3.7285,-5.64014 -1.4935,-0.71115 -3.7592,-1.18341 -5.2454,-1.09332 -4.6086,0.27937 -9.694,5.86432 -8.7325,9.59028 0.3772,1.46168 1.2803,2.83882 2.9272,4.46367 1.2845,1.26731 2.5704,2.20216 4.0199,2.92248 1.6433,0.8167 2.6324,1.00911 3.6304,0.70622 l 0,0 z m -33.041,-2.49398 c 5.9406,-1.04314 10.4643,-4.95687 12.0315,-10.40924 0.5355,-1.86288 0.6097,-2.43583 0.6103,-4.71165 6e-4,-2.05959 -0.01,-2.15555 -0.2572,-2.80136 -0.7289,-1.89034 -2.1272,-3.282 -4.5484,-4.52646 -3.8938,-2.00145 -10.10728,-3.33097 -19.04497,-4.07515 -3.62215,-0.3016 -8.30677,-0.59935 -9.42961,-0.59935 -4.43149,0 -8.5647,1.61287 -11.47763,4.47883 -1.07267,1.05537 -1.57693,1.76721 -2.24673,3.17159 -1.50587,3.15736 -1.81844,5.3825 -1.01635,7.23514 0.26074,0.60224 1.05859,1.57459 1.84446,2.24786 1.55421,1.33151 2.61653,1.99089 5.40004,3.3518 8.69265,4.24999 14.68821,6.02981 22.87738,6.79129 1.33888,0.12449 4.14041,0.0428 5.25721,-0.1533 l 0,0 z"
+       style="fill:#ffe6d5" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       inkscape:connector-curvature="0"
+       id="path3065"
+       d="m 895.06473,634.25493 c -0.13639,-0.011 -0.71667,-0.0543 -1.28951,-0.0963 -6.0341,-0.44237 -12.03892,-1.94004 -18.02827,-4.49644 -1.69722,-0.72442 -4.44298,-2.01021 -6.57152,-3.07733 -1.79726,-0.90104 -4.04691,-2.64995 -4.92749,-3.83071 -0.34241,-0.45913 -0.72898,-1.24505 -0.85062,-1.72936 -0.32668,-1.30073 -0.0601,-2.95316 0.83306,-5.16453 0.76722,-1.89949 1.31585,-2.79436 2.41425,-3.9379 1.79846,-1.87236 4.23246,-3.30085 6.93193,-4.06823 1.51208,-0.42985 2.68754,-0.59986 4.37742,-0.63315 1.10166,-0.0217 1.56896,-0.002 4.1909,0.17943 9.77417,0.67522 14.33716,1.26193 18.92099,2.43287 4.1465,1.05923 6.9521,2.42465 8.6794,4.22401 1.3968,1.45512 1.8282,2.80954 1.7432,5.4731 -0.034,1.05728 -0.1251,1.88677 -0.3088,2.8022 -1.0578,5.27229 -4.6356,9.33749 -9.7418,11.06887 -1.614,0.54727 -3.2603,0.82434 -5.08364,0.85561 -0.57283,0.01 -1.15311,0.009 -1.2895,-0.002 l 0,0 z m 3.62524,-7.48692 c 1.1497,-0.20414 2.1228,-0.73765 3.0063,-1.64827 1.4129,-1.45612 2.1632,-3.59725 1.8463,-5.26817 -0.4098,-2.16013 -2.0789,-4.31339 -4.0524,-5.2279 -1.2997,-0.6023 -2.2881,-0.6014 -3.97907,0.004 -2.65306,0.94926 -5.26559,2.98403 -6.00869,4.67986 -0.13151,0.30012 -0.14126,0.36689 -0.14126,0.96713 0,0.74294 0.0762,1.03785 0.45445,1.75863 0.33583,0.63995 0.72661,1.15343 1.38061,1.81413 1.54935,1.56521 3.5575,2.63994 5.50516,2.94629 0.6421,0.10098 1.3262,0.0923 1.9886,-0.0253 l 0,0 z m -20.95917,-2.43163 c 2.41479,-0.42113 5.34943,-2.43406 6.35615,-4.35982 0.52313,-1.0007 0.56404,-1.85722 0.13986,-2.92788 -0.78399,-1.97886 -3.11096,-4.40436 -5.18171,-5.40113 -0.82655,-0.39786 -1.0474,-0.44764 -1.98385,-0.44709 -1.20569,7.9e-4 -2.21813,0.25227 -3.47552,0.8636 -1.5872,0.77168 -3.07234,2.10921 -3.69089,3.32405 -0.34657,0.68067 -0.48019,1.55401 -0.34632,2.26351 0.5114,2.71035 4.01169,6.25886 6.62,6.71122 0.16366,0.0284 0.35337,0.0607 0.42156,0.0719 0.1745,0.0286 0.64609,-0.0121 1.14072,-0.0984 z"
+       style="fill:#ffb380" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       inkscape:connector-curvature="0"
+       id="path3067"
+       d="m 875.95875,624.1461 c -1.17834,-0.30888 -2.41847,-1.09562 -3.63902,-2.30862 -1.47449,-1.46536 -2.34052,-2.89655 -2.62652,-4.34057 -0.10451,-0.52766 0.0143,-1.2835 0.29739,-1.89177 0.43835,-0.94191 1.48891,-2.06512 2.60698,-2.78727 1.8283,-1.18088 4.07202,-1.73522 5.50519,-1.36012 1.50302,0.39337 3.72185,2.16687 5.03717,4.02618 1.28672,1.81889 1.50739,3.03395 0.79791,4.39344 -1.12186,2.14967 -4.50462,4.26723 -6.97579,4.36674 -0.46435,0.0187 -0.61371,0.004 -1.00331,-0.098 l 0,0 z"
+       style="fill:#d45500" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       sodipodi:nodetypes="cssssssc"
+       inkscape:connector-curvature="0"
+       id="path3069"
+       d="m 857.4672,632.58636 c 0,0 -7.53865,-14.08536 3.96771,-26.58365 11.50635,-12.49828 28.5675,-6.94349 51.97696,0.39677 23.4095,7.34027 22.4176,5.75318 30.7498,9.91928 8.3322,4.16609 7.5386,16.46599 3.5709,20.03693 -3.9677,3.57093 -23.2111,15.67245 -37.0981,7.34026 -13.887,-8.33219 -23.62989,-6.50327 -29.16263,-6.54672 -7.34004,-0.0577 -21.42563,3.57094 -24.00464,-4.56287 z"
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       sodipodi:nodetypes="ccsscc"
+       inkscape:connector-curvature="0"
+       id="path3071"
+       d="m 864.8697,614.20459 c -3.31029,6.85823 -1.58256,8.64554 3.34848,11.9994 6.4006,3.1783 14.6583,7.45705 26.72222,8.13209 9.76667,0.5465 17.33187,-6.5046 16.60457,-16.64443 -0.6654,-9.27681 -22.79985,-9.8552 -31.98065,-10.5526 -8.18831,-0.50369 -13.36682,4.26624 -14.69462,7.06554 z"
+       style="fill:none;stroke:#000000;stroke-width:0.19838543px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       sodipodi:nodetypes="csssc"
+       inkscape:connector-curvature="0"
+       id="path3073"
+       d="m 930.67147,618.99696 c -4.2962,0 -9.0225,4.52625 -9.3242,8.33219 -0.3135,3.95654 6.4367,9.283 9.6217,9.42331 2.8691,0.12638 8.1908,-5.22491 8.1338,-10.11766 -0.069,-5.90111 -4.1698,-7.20527 -8.4313,-7.63784 z"
+       style="fill:none;stroke:#000000;stroke-width:0.19838543px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       sodipodi:nodetypes="csssc"
+       inkscape:connector-curvature="0"
+       id="path3075"
+       d="m 897.73947,614.23571 c -2.67823,0 -8.03464,3.17417 -8.33221,5.75318 -0.29758,2.57901 3.67013,6.24914 7.43941,6.7451 3.7694,0.49597 6.15,-2.47982 6.646,-5.3564 0.4959,-2.87659 -2.4799,-6.9435 -5.7532,-7.14188 z"
+       style="fill:none;stroke:#000000;stroke-width:0.19838543px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       sodipodi:nodetypes="csssc"
+       inkscape:connector-curvature="0"
+       id="path3077"
+       d="m 877.40494,611.25993 c -3.27336,-0.19839 -7.63784,2.6782 -7.83623,5.55479 -0.19838,2.87659 4.36448,7.73703 7.43946,7.53865 3.07497,-0.19839 7.43945,-3.27336 7.43945,-5.95157 0,-2.6782 -4.56287,-7.14187 -7.04268,-7.14187 z"
+       style="fill:none;stroke:#000000;stroke-width:0.19838543px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <text
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       sodipodi:linespacing="125%"
+       id="text3912"
+       y="626.6955"
+       x="958.66669"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       xml:space="preserve"><tspan
+         style="font-size:16px;font-family:helvetica;-inkscape-font-specification:helvetica"
+         y="626.6955"
+         x="958.66669"
+         id="tspan3914"
+         sodipodi:role="line">trunk</tspan></text>
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       inkscape:connector-curvature="0"
+       id="path3916"
+       d="m 691.39073,542.37311 c -3.02055,-0.32348 -6.4511,-2.08522 -8.94635,-4.59434 -1.80617,-1.81622 -2.77769,-3.55633 -2.90535,-5.20384 -0.0808,-1.04208 0.27353,-2.00403 1.18021,-3.20452 1.99638,-2.64332 6.64908,-5.46833 10.29007,-6.24789 2.41571,-0.51721 4.89259,0.42477 7.18246,2.73157 1.6039,1.61575 2.83491,3.84228 3.20544,5.79767 0.135,0.71242 0.11609,2.10692 -0.038,2.80485 -0.65032,2.94487 -2.42781,5.48471 -4.81361,6.87809 -1.47153,0.85942 -3.33013,1.23382 -5.15484,1.03841 z"
+       style="fill:#d45500" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       inkscape:connector-curvature="0"
+       id="path3918"
+       d="m 688.30443,554.33409 c -0.21487,-0.0173 -1.12903,-0.0856 -2.03148,-0.15174 -9.50612,-0.69692 -18.9661,-3.05634 -28.40172,-7.0837 -2.67379,-1.14124 -6.99946,-3.16688 -10.35276,-4.84802 -2.8314,-1.4195 -6.37549,-4.17472 -7.76276,-6.03488 -0.53943,-0.72331 -1.14843,-1.96146 -1.34006,-2.72444 -0.51466,-2.04917 -0.0948,-4.6524 1.3124,-8.13619 1.20868,-2.99245 2.07299,-4.40223 3.80341,-6.20376 2.83328,-2.94972 6.66781,-5.20015 10.92054,-6.40909 2.38213,-0.67717 4.23395,-0.94502 6.8962,-0.99746 1.73554,-0.0342 2.47173,-0.003 6.60232,0.28268 15.39822,1.06374 22.58674,1.98804 29.80813,3.83274 6.5324,1.6687 10.95238,3.81978 13.67345,6.65449 2.2005,2.2924 2.88012,4.42615 2.74631,8.62232 -0.0531,1.66563 -0.19712,2.97241 -0.48647,4.41457 -1.66651,8.30597 -7.30301,14.71027 -15.34728,17.43789 -2.5427,0.86216 -5.13621,1.29866 -8.00874,1.34792 -0.90245,0.0155 -1.81662,0.014 -2.03149,-0.003 l 0,0 z m 5.71113,-11.79487 c 1.81126,-0.3216 3.34428,-1.16209 4.73624,-2.59669 2.22578,-2.29397 3.4079,-5.6671 2.90855,-8.29946 -0.64555,-3.40306 -3.27501,-6.79532 -6.38406,-8.23603 -2.04763,-0.94886 -3.60464,-0.94744 -6.26865,0.006 -4.17962,1.49546 -8.2954,4.70104 -9.46608,7.37265 -0.20718,0.47281 -0.22254,0.578 -0.22254,1.52361 0,1.17043 0.12006,1.63504 0.71595,2.77054 0.52907,1.00818 1.14469,1.81712 2.17501,2.85799 2.44083,2.46582 5.60447,4.15895 8.67288,4.64157 1.01147,0.15909 2.0892,0.14536 3.1327,-0.0399 l 0,0 z m -33.01897,-3.83079 c 3.80426,-0.66344 8.42749,-3.83461 10.01347,-6.86845 0.82414,-1.57651 0.88859,-2.92586 0.22034,-4.61259 -1.23511,-3.11749 -4.90101,-6.93862 -8.16326,-8.50892 -1.30214,-0.62679 -1.65008,-0.70521 -3.12536,-0.70435 -1.89944,10e-4 -3.49444,0.39744 -5.47532,1.36052 -2.50048,1.21571 -4.84016,3.32285 -5.81463,5.23671 -0.54598,1.07232 -0.75649,2.44818 -0.54559,3.56592 0.80567,4.26988 6.32001,9.8602 10.42913,10.57284 0.25784,0.0447 0.55671,0.0957 0.66414,0.11328 0.27491,0.045 1.01784,-0.0191 1.79708,-0.15496 z"
+       style="fill:#ffb380" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       inkscape:connector-curvature="0"
+       id="path3920"
+       d="m 658.20491,538.40866 c -1.85636,-0.4866 -3.81006,-1.72604 -5.73291,-3.63698 -2.32291,-2.30853 -3.68725,-4.56323 -4.13781,-6.83814 -0.16465,-0.83127 0.0225,-2.02202 0.4685,-2.98029 0.69057,-1.48388 2.34562,-3.25339 4.10703,-4.39106 2.88031,-1.86035 6.41505,-2.73366 8.67288,-2.14273 2.36785,0.61971 5.86339,3.41368 7.93554,6.34283 2.0271,2.86548 2.37474,4.77968 1.25703,6.92142 -1.76737,3.38659 -7.09657,6.72259 -10.98966,6.87937 -0.73152,0.0295 -0.96682,0.006 -1.5806,-0.15442 l 0,0 z"
+       style="fill:#d45500" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       sodipodi:nodetypes="ccsscc"
+       inkscape:connector-curvature="0"
+       id="path3922"
+       d="m 640.73523,522.74683 c -5.21502,10.80445 -2.49316,13.62016 5.27519,18.90383 10.0835,5.00709 23.09267,11.74783 42.09814,12.81129 15.38639,0.86095 27.30458,-10.24734 26.1588,-26.22162 -1.04826,-14.61467 -35.91882,-15.52586 -50.38225,-16.62454 -12.89985,-0.79352 -21.05806,6.72102 -23.14988,11.13104 z"
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       sodipodi:nodetypes="csssc"
+       inkscape:connector-curvature="0"
+       id="path3924"
+       d="m 692.51818,522.79585 c -4.21924,0 -12.65772,5.00058 -13.12652,9.06355 -0.4688,4.06297 5.78192,9.84489 11.7201,10.62623 5.93819,0.78134 9.68862,-3.90671 10.46996,-8.43848 0.78134,-4.53177 -3.9067,-10.93876 -9.06354,-11.2513 z"
+       style="fill:none;stroke:#000000;stroke-width:0.31253609px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_tree.png"
+       sodipodi:nodetypes="csssc"
+       inkscape:connector-curvature="0"
+       id="path3926"
+       d="m 660.48323,518.10781 c -5.15685,-0.31254 -12.03264,4.21924 -12.34518,8.75101 -0.31254,4.53177 6.87579,12.18891 11.7201,11.87637 4.84431,-0.31253 11.72011,-5.15684 11.72011,-9.37608 0,-4.21924 -7.18833,-11.2513 -11.09503,-11.2513 z"
+       style="fill:none;stroke:#000000;stroke-width:0.31253609px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_structure_unlabelled.png"
+       inkscape:connector-curvature="0"
+       id="path3967"
+       d="m 446.04606,941.05083 c -14.47797,-3.3577 -34.77526,-20.0128 -41.6888,-34.20828 -2.12786,-4.36907 -2.87184,-7.2515 -2.86504,-11.1 0.0129,-7.30402 4.21141,-16.45705 11.1464,-24.3 1.55059,-1.7536 5.12043,-5.22386 7.00744,-6.81197 6.15894,-5.18336 14.67204,-9.5076 21.4,-10.87013 4.61498,-0.93462 6.2142,-0.96263 11.6,-0.20318 12.18815,1.71866 20.72362,4.9943 26.73606,10.26047 7.0284,6.15602 10.58278,15.33422 10.58186,27.32481 -4e-4,5.04434 -0.73635,9.13307 -2.55598,14.2 -4.73097,13.17378 -16.01793,26.75118 -27.56194,33.15498 -5.14514,2.8542 -9.23749,3.6114 -13.8,2.5533 z"
+       style="fill:#ffb380" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_structure_unlabelled.png"
+       inkscape:connector-curvature="0"
+       id="path3969"
+       d="m 278.39258,891.16883 c -9.66463,-1.03501 -20.64112,-6.67193 -28.625,-14.7002 -5.77909,-5.81123 -8.88758,-11.37892 -9.29605,-16.65035 -0.25836,-3.33427 0.87521,-6.41216 3.77622,-10.25327 6.3877,-8.45767 21.2746,-17.49665 32.92444,-19.99094 7.72936,-1.6549 15.65447,1.35911 22.98122,8.74001 5.13187,5.1698 9.07065,12.29387 10.25622,18.5504 0.43195,2.27946 0.37144,6.74136 -0.1217,8.97447 -2.08076,9.42251 -7.76809,17.54904 -15.40177,22.00735 -4.70835,2.74983 -10.65518,3.94778 -16.49358,3.32253 z"
+       style="fill:#d45500" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_structure_unlabelled.png"
+       inkscape:connector-curvature="0"
+       id="path3971"
+       d="m 395.03388,990.81293 c -14.78107,-0.8271 -28.78041,-4.3829 -40.75,-10.3504 -1.925,-0.9598 -6.875,-3.6634 -11,-6.0081 -29.86093,-16.9735 -58.28955,-26.8145 -87,-30.1162 -14.75473,-1.6968 -51.11301,-1.5586 -75.25,0.2861 -5.3625,0.4098 -15.6,1.1876 -22.75,1.7285 -25.66235,1.9411 -42.74596,0.9894 -55.25,-3.078 -10.83703,-3.5252 -19.23548,-10.9784 -22.97977,-20.3933 -0.50067,-1.2589 -2.06032,-5.0869 -3.46589,-8.5066 -4.10779,-9.99412 -7.09254,-21.62664 -8.60396,-33.53238 -0.89002,-7.01079 -0.73673,-22.55069 0.29346,-29.75 3.53774,-24.72297 14.50953,-46.48012 33.23206,-65.89942 15.58368,-16.16364 32.85567,-26.14724 54.1304,-31.28859 11.96037,-2.8904 16.4616,-3.31446 34.8937,-3.28737 14.35147,0.0211 17.96059,0.18392 25.20408,1.13709 32.64044,4.29514 60.54997,11.32769 127.29592,32.07562 52.80839,16.41545 74.04142,22.74586 105.75,31.5283 36.7641,10.18268 44.94113,13.07738 64.29562,22.76093 11.03672,5.52196 17.83931,11.16505 23.54669,19.53316 11.98292,17.56925 14.86589,44.15891 7.13556,65.81136 -3.20016,8.9636 -7.43327,14.6158 -15.47787,20.6667 -33.97151,25.5524 -81.21807,44.558 -115.5,46.4613 -2.75,0.1527 -6.35,0.35 -8,0.4383 -1.65,0.088 -6.0375,-0.01 -9.75,-0.217 l 0,0 z m 59.54972,-49.1792 c 6.01581,-1.8259 12.50622,-6.3532 19.26543,-13.4383 12.19214,-12.7799 18.13109,-27.65582 16.66927,-41.7532 -1.48728,-14.34278 -7.12764,-22.87513 -18.79397,-28.4302 -7.52828,-3.58469 -18.94926,-5.96522 -26.44045,-5.51111 -23.23075,1.40822 -48.86483,29.56023 -44.01793,48.34163 1.90143,7.36792 6.4537,14.30958 14.75521,22.49998 6.47479,6.3881 12.95647,11.1004 20.26272,14.7314 8.28371,4.1167 13.26955,5.0866 18.29972,3.5598 l 0,0 z m -166.54972,-12.5714 c 29.94496,-5.2582 52.7474,-24.98604 60.64713,-52.46978 2.69906,-9.3902 3.07315,-12.27829 3.07631,-23.75 0.003,-10.38176 -0.0415,-10.86546 -1.29665,-14.12077 -3.67377,-9.52864 -10.7226,-16.54356 -22.92679,-22.8165 -19.62778,-10.08867 -50.94785,-16.79038 -96,-20.54159 -18.25815,-1.52024 -41.87189,-3.02114 -47.53179,-3.02114 -22.33777,0 -43.17202,8.13 -57.85517,22.57641 -5.40699,5.31981 -7.94882,8.90797 -11.32509,15.98703 -7.59062,15.91529 -9.16621,27.13152 -5.12312,36.47012 1.3143,3.03572 5.33602,7.937 9.29738,11.33075 7.8343,6.71173 13.18912,10.03546 27.21995,16.89539 43.81696,21.42288 74.03873,30.39438 115.31784,34.23278 6.74887,0.6276 20.87065,0.2158 26.5,-0.7727 l 0,0 z"
+       style="fill:#ffe6d5" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_structure_unlabelled.png"
+       inkscape:connector-curvature="0"
+       id="path3973"
+       d="m 268.51758,929.43953 c -0.6875,-0.055 -3.6125,-0.2738 -6.5,-0.4855 -30.41608,-2.2299 -60.6845,-9.7792 -90.875,-22.66522 -8.55513,-3.65154 -22.3957,-10.13285 -33.125,-15.51187 -9.05944,-4.54186 -20.39923,-13.35757 -24.83798,-19.30939 -1.72598,-2.31433 -3.67456,-6.27594 -4.28769,-8.71719 -1.64671,-6.5566 -0.30315,-14.88597 4.19918,-26.03281 3.86735,-9.57473 6.63283,-14.08552 12.16951,-19.84973 9.06547,-9.43803 21.33455,-16.63856 34.94171,-20.50671 7.62194,-2.16672 13.54707,-3.02373 22.06527,-3.19152 5.55309,-0.10939 7.90864,-0.009 21.125,0.90448 49.26861,3.40357 72.26921,6.36099 95.375,12.26335 20.90127,5.33921 35.04356,12.22187 43.75,21.29191 7.04078,7.33482 9.21532,14.16203 8.78716,27.58822 -0.16995,5.32942 -0.63071,9.51064 -1.55653,14.125 -5.3322,26.57603 -23.36692,47.06748 -49.10563,55.79478 -8.1357,2.7586 -16.43395,4.1553 -25.625,4.3129 -2.8875,0.049 -5.8125,0.045 -6.5,-0.011 l 0,0 z m 18.27351,-37.7392 c 5.79536,-1.02901 10.70046,-3.71828 15.1542,-8.30845 7.12169,-7.33986 10.90404,-18.13264 9.3063,-26.5552 -2.06552,-10.88855 -10.47883,-21.74251 -20.42663,-26.35227 -6.55167,-3.03601 -11.53352,-3.03145 -20.05738,0.0184 -13.37323,4.78493 -26.54222,15.0416 -30.28794,23.58976 -0.6629,1.51281 -0.71206,1.84939 -0.71206,4.875 0,3.74494 0.38415,5.2315 2.29076,8.86469 1.69283,3.22582 3.66261,5.81412 6.95924,9.14451 7.80977,7.88973 17.93224,13.3071 27.75,14.85132 3.23635,0.50903 6.68469,0.46509 10.02351,-0.12774 l 0,0 z M 181.14258,879.44321 c 12.17222,-2.12277 26.96484,-12.26934 32.03939,-21.97651 2.63694,-5.04424 2.84318,-9.36167 0.70501,-14.75856 -3.95188,-9.97483 -15.68141,-22.20103 -26.1194,-27.22541 -4.16639,-2.00551 -5.27965,-2.25641 -10,-2.25366 -6.0775,0.004 -11.18091,1.27165 -17.51902,4.35317 -8.00059,3.8898 -15.48672,10.63188 -18.60465,16.75552 -1.74695,3.43102 -2.42051,7.83328 -1.7457,11.40963 2.57784,13.66203 20.22169,31.54901 33.36937,33.82919 0.825,0.14308 1.78125,0.30618 2.125,0.36244 0.8796,0.14398 3.25671,-0.061 5.75,-0.49581 z"
+       style="fill:#ffb380" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_structure_unlabelled.png"
+       inkscape:connector-curvature="0"
+       id="path3975"
+       d="m 172.21023,878.48406 c -5.93966,-1.55694 -12.1908,-5.52269 -18.3432,-11.63701 -7.43244,-7.38643 -11.79783,-14.60065 -13.23947,-21.8795 -0.5268,-2.65976 0.0721,-6.46973 1.49904,-9.53583 2.20957,-4.74786 7.50513,-10.40966 13.14098,-14.04978 9.21591,-5.95244 20.5258,-8.74668 27.75,-6.85595 7.57626,1.98287 18.7607,10.92254 25.3908,20.29474 6.48597,9.16846 7.59831,15.2932 4.02203,22.14597 -5.65494,10.83584 -22.70639,21.50981 -35.16283,22.01143 -2.34061,0.0943 -3.09349,0.0207 -5.05735,-0.49407 l 0,0 z"
+       style="fill:#d45500" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_structure_unlabelled.png"
+       sodipodi:nodetypes="cssssssc"
+       inkscape:connector-curvature="0"
+       id="path3977"
+       d="m 79,921.02883 c 0,0 -38,-70.99999 20,-133.99999 58,-63 144,-35 262,2 118,37 113,29 155,50 42,21 38,82.99999 18,100.99999 -20,18 -117,78.99997 -187,37 -70,-42 -119.11116,-32.781 -147,-33 -36.99886,-0.2906 -108,18 -121,-23 z"
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_structure_unlabelled.png"
+       sodipodi:nodetypes="ccsscc"
+       inkscape:connector-curvature="0"
+       id="path3979"
+       d="m 116.3137,828.37199 c -16.68613,34.57024 -7.97718,43.57949 16.87868,60.48528 32.26346,16.02082 73.888,37.58876 134.69849,40.99136 49.23076,2.7547 87.36456,-32.78767 83.69848,-83.89948 -3.35405,-46.76152 -114.92695,-49.67702 -161.20458,-53.19239 -41.27476,-2.53896 -67.37802,21.50481 -74.07107,35.61523 z"
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_structure_unlabelled.png"
+       sodipodi:nodetypes="csssc"
+       inkscape:connector-curvature="0"
+       id="path3981"
+       d="m 448,852.52884 c -21.65583,0 -45.47961,22.81545 -47,42 -1.58055,19.94369 32.44541,46.79279 48.5,47.49999 14.46208,0.6371 41.2873,-26.3372 41,-50.99999 -0.34651,-29.74569 -21.01902,-36.31957 -42.5,-38.5 z"
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_structure_unlabelled.png"
+       sodipodi:nodetypes="csssc"
+       inkscape:connector-curvature="0"
+       id="path3983"
+       d="m 282,828.52884 c -13.5,0 -40.5,16 -42,29 -1.5,13 18.5,31.5 37.5,34 19,2.5 31,-12.5 33.5,-27 2.5,-14.5 -12.5,-35 -29,-36 z"
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/schematic_structure_unlabelled.png"
+       sodipodi:nodetypes="csssc"
+       inkscape:connector-curvature="0"
+       id="path3985"
+       d="m 179.5,813.52884 c -16.5,-1 -38.5,13.5 -39.5,28 -1,14.5 22,39 37.5,38 15.5,-1 37.5,-16.5 37.5,-30 0,-13.5 -23,-36 -35.5,-36 z"
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       style="fill:#d45500;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 778.93931,864.26921 c -2.40861,-0.25806 -5.14413,-1.66275 -7.13387,-3.66354 -1.44026,-1.44826 -2.21494,-2.83582 -2.31673,-4.14958 -0.0644,-0.83096 0.21796,-1.59802 0.94108,-2.55528 1.59195,-2.10783 5.30203,-4.36049 8.20536,-4.98211 1.9263,-0.41243 3.90137,0.33871 5.72734,2.17817 1.27896,1.28841 2.26057,3.06386 2.55603,4.62309 0.10769,0.56809 0.0925,1.68008 -0.0304,2.2366 -0.51854,2.34826 -1.93595,4.37352 -3.83839,5.48461 -1.17339,0.68532 -2.65547,0.98387 -4.11049,0.82804 z"
+       id="path4007"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       style="fill:#ffb380;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 868.93959,922.8078 c -2.595,-0.6018 -6.23302,-3.58704 -7.47217,-6.13138 -0.38138,-0.7831 -0.51474,-1.29972 -0.51353,-1.98951 0.002,-1.30915 0.75486,-2.94972 1.99784,-4.35545 0.27782,-0.31433 0.91777,-0.93632 1.25599,-1.22096 1.10393,-0.92905 2.62978,-1.70413 3.83567,-1.94832 0.82718,-0.16755 1.11382,-0.17242 2.07916,-0.0364 2.18455,0.30803 3.7144,0.89514 4.79207,1.83903 1.25974,1.10339 1.8968,2.74846 1.89666,4.89761 -9e-5,0.90414 -0.13204,1.63697 -0.45814,2.54518 -0.84794,2.36121 -2.87099,4.79479 -4.94009,5.94258 -0.92221,0.51158 -1.6557,0.64728 -2.47346,0.45765 z"
+       id="path4009"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       style="fill:none;stroke:#000000;stroke-width:0.60779828;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 869.28981,906.94142 c -3.88152,0 -8.15162,4.08937 -8.42414,7.52793 -0.28326,3.57467 5.81542,8.387 8.69297,8.51376 2.59214,0.11428 7.4002,-4.72059 7.3487,-9.14108 -0.0622,-5.33152 -3.76736,-6.50981 -7.61753,-6.90061 z"
+       id="path4011"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssc" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       style="fill:none;stroke:#000000;stroke-width:0.60779828;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 779.83832,848.65821 c -3.36441,0 -10.0933,3.9875 -10.46712,7.22733 -0.37385,3.23982 4.61052,7.85034 9.34566,8.4734 4.73514,0.62305 7.72573,-3.11524 8.34879,-6.72889 0.62305,-3.61365 -3.11521,-8.72261 -7.22733,-8.97184 z"
+       id="path4013"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssc" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       style="fill:#d45500"
+       d="m 664.13945,855.44624 c -1.45046,-0.38021 -2.97699,-1.34864 -4.47944,-2.84177 -1.815,-1.80378 -2.88104,-3.56551 -3.23309,-5.34302 -0.1286,-0.64951 0.0172,-1.57991 0.36606,-2.32864 0.53959,-1.15944 1.83278,-2.54205 3.20906,-3.43098 2.25055,-1.45361 5.01244,-2.13595 6.77658,-1.67423 1.85014,0.4842 4.58139,2.6673 6.20049,4.95599 1.58387,2.23897 1.8555,3.73463 0.98218,5.40808 -1.38095,2.64613 -5.54493,5.25274 -8.58682,5.37524 -0.57159,0.0229 -0.75543,0.006 -1.23502,-0.12058 l 0,0 z"
+       id="path4015"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       style="fill:none;stroke:#000000;stroke-width:0.60779828;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 665.91962,839.5841 c -4.02931,-0.24431 -9.40174,3.2967 -9.64596,6.83763 -0.24431,3.54093 5.37245,9.52387 9.15758,9.27964 3.78512,-0.2443 9.15754,-4.02931 9.15754,-7.32604 0,-3.29671 -5.61664,-8.79123 -8.66916,-8.79123 z"
+       id="path4017"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssc" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       inkscape:connector-curvature="0"
+       id="path4019"
+       d="m 796.54956,1023.6749 0,-55.26284"
+       style="fill:none;stroke:#000000;stroke-width:2.86408734;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       inkscape:connector-curvature="0"
+       id="path4021"
+       d="m 723.89957,968.41206 146.25809,0"
+       style="fill:none;stroke:#000000;stroke-width:2.86408734;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       style="fill:none;stroke:#000000;stroke-width:2.86408734;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 724.58484,969.16781 0,-55.26285"
+       id="path4023"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       inkscape:connector-curvature="0"
+       id="path4025"
+       d="m 869.35385,968.4041 0,-41.63034"
+       style="fill:none;stroke:#000000;stroke-width:2.86408734;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       inkscape:transform-center-y="-6.2310354"
+       style="fill:none;stroke:#000000;stroke-width:2.86408734;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 663.69379,914.25014 115.50776,0"
+       id="path4027"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       inkscape:connector-curvature="0"
+       id="path4029"
+       d="m 778.57343,914.86486 0,-45.77938"
+       style="fill:#ff9955;stroke:#000000;stroke-width:2.86408734;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    <path
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       style="fill:#ff9955;stroke:#000000;stroke-width:2.86408734;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 664.44347,914.99847 0,-55.26286"
+       id="path4031"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#ffb380"
+       d="m 849.0632,1005.8944 c -1.74572,-0.4049 -4.19314,-2.4132 -5.02673,-4.1248 -0.25662,-0.5268 -0.34633,-0.8744 -0.34547,-1.3384 0,-0.88075 0.50783,-1.9844 1.34403,-2.93009 0.18703,-0.21137 0.61741,-0.62987 0.84496,-0.82136 0.74261,-0.62501 1.76912,-1.14641 2.58035,-1.31073 0.55643,-0.11255 0.7493,-0.11599 1.39873,-0.0258 1.46959,0.20736 2.49877,0.6022 3.22376,1.2372 0.84746,0.74228 1.27607,1.84897 1.27595,3.29476 -6e-5,0.60822 -0.0888,1.10132 -0.30823,1.71222 -0.57041,1.5885 -1.9314,3.2256 -3.32337,3.9978 -0.62039,0.3441 -1.11379,0.4354 -1.66398,0.3079 z"
+       id="path4049"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:#d45500"
+       d="m 828.84784,999.87968 c -1.16534,-0.12488 -2.48886,-0.8045 -3.45154,-1.77253 -0.69683,-0.7007 -1.07166,-1.37204 -1.12092,-2.00767 -0.0312,-0.40203 0.10569,-0.77316 0.45533,-1.23631 0.77021,-1.01982 2.56528,-2.10972 3.96997,-2.41047 0.93201,-0.19963 1.88758,0.16382 2.77104,1.05384 0.61878,0.62337 1.09371,1.48236 1.23668,2.23676 0.0521,0.27496 0.045,0.81289 -0.0143,1.08214 -0.25089,1.13616 -0.93667,2.11605 -1.8571,2.65361 -0.56769,0.33157 -1.28477,0.47601 -1.9888,0.40063 z"
+       id="path4051"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:#ffe6d5"
+       d="m 842.91223,1011.8946 c -1.78224,-0.1 -3.47027,-0.5285 -4.91357,-1.248 -0.23199,-0.1158 -0.82896,-0.4418 -1.32633,-0.7245 -3.60059,-2.0466 -7.02845,-3.2332 -10.49033,-3.6314 -1.77908,-0.2045 -6.16311,-0.1878 -9.07351,0.035 -0.6466,0.05 -1.88102,0.1432 -2.74314,0.2085 -3.09433,0.234 -5.15424,0.1192 -6.66195,-0.3711 -1.30671,-0.4251 -2.3194,-1.3238 -2.77086,-2.459 -0.0604,-0.1518 -0.24832,-0.6134 -0.41793,-1.0257 -0.49531,-1.2051 -0.85519,-2.6077 -1.03743,-4.04329 -0.1074,-0.84533 -0.0888,-2.71911 0.0352,-3.58721 0.42655,-2.98106 1.74953,-5.60448 4.00706,-7.94604 1.87904,-1.94898 3.96166,-3.15279 6.52694,-3.77272 1.44218,-0.34853 1.98493,-0.39965 4.20743,-0.39639 1.73048,0.002 2.16565,0.0229 3.03905,0.13719 3.93575,0.51792 7.30102,1.36589 15.34916,3.86764 6.36753,1.97934 8.92776,2.74265 12.75118,3.80162 4.43292,1.22783 5.41888,1.57685 7.75265,2.74448 1.33077,0.66584 2.15099,1.34626 2.8392,2.35528 1.44485,2.11848 1.79252,5.32464 0.8604,7.93544 -0.38591,1.0808 -0.89631,1.7623 -1.8663,2.4919 -4.09627,3.0811 -9.79317,5.3728 -13.92679,5.6023 -0.33161,0.017 -0.76572,0.042 -0.96463,0.053 -0.19905,0.011 -0.72802,-10e-4 -1.17568,-0.026 l 0,0 z m 7.18041,-5.9299 c 0.72541,-0.2203 1.508,-0.7661 2.323,-1.6204 1.47014,-1.541 2.18625,-3.3347 2.00999,-5.03455 -0.17929,-1.72942 -0.85943,-2.75826 -2.26618,-3.42808 -0.90774,-0.43222 -2.28483,-0.71926 -3.18813,-0.6645 -2.80111,0.16984 -5.892,3.56433 -5.30761,5.82893 0.22941,0.8884 0.77817,1.7254 1.77914,2.713 0.78072,0.7703 1.5623,1.3385 2.44329,1.7763 0.9988,0.4964 1.59997,0.6133 2.20656,0.4293 l 0,0 z m -20.08227,-1.5159 c 3.6107,-0.634 6.3602,-3.0128 7.31273,-6.3267 0.32548,-1.13226 0.37059,-1.4805 0.37093,-2.86374 3.7e-4,-1.25181 -0.006,-1.31015 -0.15638,-1.70267 -0.44301,-1.14893 -1.2929,-1.99478 -2.7645,-2.75116 -2.36665,-1.21649 -6.14318,-2.02457 -11.5755,-2.47686 -2.20153,-0.18331 -5.04884,-0.36429 -5.73129,-0.36429 -2.69348,0 -5.20562,0.98029 -6.97609,2.7222 -0.65198,0.64147 -0.95847,1.07412 -1.36557,1.92771 -0.91527,1.91902 -1.10525,3.27147 -0.61772,4.39749 0.15838,0.36606 0.64339,0.95703 1.12106,1.36625 0.94463,0.80928 1.59031,1.21005 3.28213,2.03727 5.28338,2.5831 8.92747,3.6649 13.90483,4.1277 0.81377,0.076 2.51653,0.026 3.19532,-0.093 l 0,0 z"
+       id="path4053"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:#ffb380"
+       d="m 827.65715,1004.4943 c -0.0831,-0.01 -0.4356,-0.033 -0.78378,-0.058 -3.6675,-0.2689 -7.31723,-1.1792 -10.95754,-2.7329 -1.03156,-0.4403 -2.70044,-1.2218 -3.99417,-1.87045 -1.09237,-0.54764 -2.45971,-1.61065 -2.99492,-2.3283 -0.20822,-0.27896 -0.44308,-0.75675 -0.517,-1.05109 -0.19848,-0.7906 -0.0364,-1.79492 0.50634,-3.13901 0.46631,-1.15452 0.79977,-1.69841 1.46736,-2.39343 1.09311,-1.13802 2.5725,-2.00627 4.21322,-2.47269 0.91905,-0.2612 1.6335,-0.36459 2.66059,-0.38481 0.6696,-0.0143 0.95363,-10e-4 2.54723,0.10912 5.94072,0.41039 8.7141,0.767 11.50015,1.4787 2.52022,0.64379 4.22547,1.47369 5.27533,2.56734 0.84897,0.8844 1.11115,1.70762 1.05951,3.32652 -0.0201,0.64261 -0.0759,1.14678 -0.1876,1.70319 -0.64293,3.20451 -2.81749,5.67531 -5.92104,6.72761 -0.98098,0.3327 -1.9816,0.5011 -3.08983,0.5201 -0.34816,0.01 -0.70085,0.01 -0.78373,-10e-4 l 0,0 z m 2.2034,-4.55053 c 0.69878,-0.12401 1.29025,-0.44834 1.82723,-1.00182 0.85874,-0.88504 1.31479,-2.18642 1.12218,-3.202 -0.24917,-1.31292 -1.26355,-2.62167 -2.46306,-3.1775 -0.78994,-0.36606 -1.39068,-0.36552 -2.41846,0.002 -1.61251,0.57697 -3.20042,1.81369 -3.65206,2.84441 -0.0799,0.18245 -0.0859,0.22312 -0.0859,0.58783 0,0.45155 0.0464,0.63079 0.2761,1.06888 0.20421,0.38897 0.44161,0.70107 0.83912,1.10264 0.94171,0.95134 2.16224,1.60455 3.34603,1.79074 0.39026,0.0614 0.80607,0.0562 1.20867,-0.0143 l 0,0 z m -12.73894,-1.47795 c 1.4677,-0.25605 3.25137,-1.47942 3.86325,-2.64988 0.31797,-0.60822 0.34283,-1.12883 0.0851,-1.77958 -0.47649,-1.20274 -1.89084,-2.67694 -3.14943,-3.28278 -0.50236,-0.24173 -0.6366,-0.27209 -1.20578,-0.27181 -0.73281,4.9e-4 -1.34819,0.15323 -2.11241,0.52491 -0.96471,0.46902 -1.86736,1.28196 -2.24333,2.02035 -0.21051,0.41369 -0.29185,0.94452 -0.21051,1.37574 0.31081,1.64736 2.43829,3.80414 4.02362,4.07909 0.0994,0.0172 0.2148,0.0369 0.25633,0.0438 0.10597,0.0172 0.3927,-0.009 0.69334,-0.0599 z"
+       id="path4055"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:#d45500"
+       d="m 816.04457,998.35017 c -0.7162,-0.1876 -1.46997,-0.66593 -2.21179,-1.40318 -0.89621,-0.89064 -1.42257,-1.76052 -1.59642,-2.63819 -0.0636,-0.32069 0.009,-0.78009 0.18073,-1.14982 0.26636,-0.57247 0.90496,-1.25516 1.58452,-1.69408 1.11124,-0.71774 2.47498,-1.05467 3.34606,-0.82669 0.91353,0.23915 2.26211,1.31702 3.06157,2.44711 0.78206,1.10551 0.91619,1.84404 0.48497,2.67033 -0.68185,1.30657 -2.73789,2.5936 -4.23988,2.65409 -0.28211,0.0115 -0.37302,0.002 -0.60979,-0.0596 l 0,0 z"
+       id="path4057"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.60779828;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 804.80543,1003.4802 c 0,0 -4.582,-8.56112 2.41156,-16.15754 6.99353,-7.59645 17.36327,-4.22026 31.59152,0.24115 14.22824,4.46139 13.62538,3.49677 18.68966,6.02891 5.0643,2.53214 4.58196,10.00798 2.1704,12.17838 -2.41156,2.1704 -14.10766,9.5257 -22.54816,4.4614 -8.44049,-5.0643 -14.36222,-3.9526 -17.725,-3.9791 -4.46128,-0.035 -13.02246,2.1705 -14.58998,-2.7732 z"
+       id="path4059"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cssssssc"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.1205783px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 809.30465,992.30774 c -2.01199,4.16843 -0.96187,5.25475 2.0352,7.2932 3.89029,1.93176 8.90928,4.53236 16.24172,4.94266 5.93616,0.3322 10.53428,-3.9535 10.09224,-10.11643 -0.40444,-5.63844 -13.85771,-5.98998 -19.43779,-6.41387 -4.97683,-0.30614 -8.12432,2.59303 -8.93137,4.29444 z"
+       id="path4061"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccsscc"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.1205783px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 849.29886,995.22052 c -2.61122,0 -5.48387,2.75104 -5.66723,5.06428 -0.19046,2.4048 3.9122,5.6422 5.84804,5.7275 1.74382,0.077 4.97835,-3.1757 4.94373,-6.14949 -0.0421,-3.5867 -2.53441,-4.37936 -5.12454,-4.64229 z"
+       id="path4063"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssc"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.1205783px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 829.28284,992.32665 c -1.62784,0 -4.88344,1.92925 -5.06431,3.49676 -0.18072,1.56752 2.23069,3.79824 4.52168,4.09969 2.29101,0.3014 3.73795,-1.50726 4.03942,-3.25564 0.30142,-1.74838 -1.50728,-4.22023 -3.49679,-4.34081 z"
+       id="path4065"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssc"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.1205783px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 816.92356,990.51798 c -1.98954,-0.12058 -4.64229,1.6278 -4.76287,3.37618 -0.12057,1.74839 2.65275,4.70255 4.52171,4.582 1.86896,-0.12058 4.52168,-1.98957 4.52168,-3.61737 0,-1.62781 -2.7733,-4.34081 -4.28052,-4.34081 z"
+       id="path4067"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssc"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:#d45500"
+       d="m 703.86442,948.64869 c -1.83588,-0.19648 -3.92096,-1.26739 -5.43755,-2.79243 -1.09781,-1.10391 -1.6883,-2.16153 -1.76588,-3.1629 -0.049,-0.63336 0.16611,-1.21804 0.71734,-1.94769 1.21339,-1.60661 4.04128,-3.32363 6.25427,-3.79747 1.46828,-0.31436 2.97373,0.25806 4.3655,1.66026 0.97485,0.98203 1.72304,2.33532 1.94827,3.5238 0.0819,0.43302 0.0705,1.28059 -0.0229,1.70479 -0.39528,1.78988 -1.47561,3.33359 -2.9257,4.18051 -0.89439,0.52235 -2.02405,0.7499 -3.13311,0.63113 z"
+       id="path4073"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:#ffb380"
+       d="m 701.98859,955.91854 c -0.1306,-0.0115 -0.68624,-0.0521 -1.23474,-0.0922 -5.77781,-0.42357 -11.52755,-1.85765 -17.26251,-4.30547 -1.62511,-0.69363 -4.25426,-1.92481 -6.2924,-2.9466 -1.72092,-0.86278 -3.875,-2.53738 -4.71818,-3.66798 -0.32786,-0.43964 -0.69801,-1.19218 -0.81449,-1.65593 -0.31282,-1.24548 -0.0576,-2.82771 0.79767,-4.94516 0.73464,-1.81881 1.25997,-2.67566 2.31172,-3.77063 1.72207,-1.79283 4.05269,-3.16064 6.63747,-3.89545 1.44785,-0.41157 2.57341,-0.57436 4.1915,-0.60624 1.05488,-0.02 1.50233,-0.002 4.01288,0.17185 9.359,0.64654 13.7282,1.20833 18.11733,2.32953 3.97039,1.01423 6.65685,2.32166 8.31072,4.04458 1.33744,1.39332 1.75053,2.69021 1.66919,5.24062 -0.0324,1.01237 -0.11972,1.80664 -0.29569,2.68319 -1.01288,5.04836 -4.43873,8.94085 -9.32805,10.5987 -1.54543,0.52401 -3.12176,0.78934 -4.86768,0.81927 -0.54851,0.009 -1.10414,0.009 -1.23474,-0.002 l 0,0 z m 3.47122,-7.1689 c 1.10087,-0.19561 2.03264,-0.70631 2.87866,-1.57825 1.35282,-1.39427 2.07134,-3.44447 1.76783,-5.0444 -0.39238,-2.06839 -1.99054,-4.13019 -3.88024,-5.00586 -1.24453,-0.57671 -2.19088,-0.57585 -3.81006,0.003 -2.54036,0.90892 -5.04194,2.85727 -5.75347,4.48106 -0.12602,0.28739 -0.13518,0.35131 -0.13518,0.92605 0,0.71138 0.073,0.99378 0.43517,1.68394 0.32155,0.61277 0.69574,1.10445 1.32195,1.73707 1.48354,1.49872 3.4064,2.52781 5.27138,2.82115 0.61477,0.0968 1.26979,0.0882 1.90404,-0.0229 l 0,0 z m -20.06889,-2.32833 c 2.31223,-0.40326 5.12222,-2.33068 6.08618,-4.17463 0.5009,-0.95821 0.54008,-1.77834 0.13404,-2.80354 -0.7507,-1.8948 -2.97882,-4.21729 -4.96163,-5.17171 -0.79143,-0.38096 -1.00292,-0.42862 -1.89958,-0.4281 -1.15448,6e-4 -2.12392,0.24144 -3.32789,0.82692 -1.51977,0.73891 -2.94185,2.01964 -3.53412,3.18286 -0.33186,0.65175 -0.4598,1.48801 -0.3316,2.16737 0.48967,2.59523 3.84129,5.99302 6.3388,6.42615 0.15666,0.0258 0.33836,0.0581 0.40366,0.0687 0.16698,0.0286 0.61865,-0.0115 1.09225,-0.0942 z"
+       id="path4075"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:#d45500"
+       d="m 683.69415,946.2391 c -1.12828,-0.29575 -2.31573,-1.04909 -3.48445,-2.21056 -1.41186,-1.40312 -2.24109,-2.77352 -2.51496,-4.15619 -0.1,-0.50526 0.0143,-1.22898 0.28469,-1.81142 0.41973,-0.9019 1.42569,-1.9774 2.49625,-2.66887 1.75065,-1.13072 3.89906,-1.66152 5.27136,-1.30236 1.43917,0.37666 3.56378,2.07483 4.82321,3.85518 1.23207,1.74162 1.44338,2.90507 0.76402,4.2068 -1.0742,2.05839 -4.31329,4.08599 -6.67948,4.18128 -0.44462,0.0172 -0.58765,0.003 -0.9607,-0.094 l 0,0 z"
+       id="path4077"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.60779828;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 673.07611,936.71988 c -3.16968,6.56692 -1.51533,8.2783 3.20626,11.48971 6.12872,3.0433 14.03566,7.14032 25.58716,7.78668 9.35182,0.52327 16.5957,-6.22833 15.89929,-15.93747 -0.63714,-8.88277 -21.83142,-9.43659 -30.62225,-10.10436 -7.84052,-0.48231 -12.79906,4.08502 -14.07046,6.76544 z"
+       id="path4079"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccsscc"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.18995892px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 704.54969,936.74966 c -2.56445,0 -7.69334,3.03934 -7.97826,5.50882 -0.28498,2.46947 3.51423,5.98371 7.12344,6.4586 3.60924,0.47489 5.88873,-2.3745 6.36363,-5.12889 0.47489,-2.7544 -2.37447,-6.64855 -5.50881,-6.83853 z"
+       id="path4081"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssc"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.18995892px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 685.0789,933.90027 c -3.13431,-0.18989 -7.31342,2.56444 -7.50336,5.31887 -0.18989,2.75439 4.17907,7.40839 7.12344,7.21841 2.94437,-0.18989 7.12347,-3.13431 7.12347,-5.69876 0,-2.56444 -4.36905,-6.83852 -6.74355,-6.83852 z"
+       id="path4083"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssc"
+       inkscape:export-filename="/Users/tom/dendrograms_org.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+  </g>
+</svg>


### PR DESCRIPTION
Since Illustrator is not available for free, I thought it might make sense to use InkScape instead (which is what I used for the current diagrams). This can be extended to make diagrams for the 'compute' section of the docs (#23).
