### PR TITLE
Consolidate licenses

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 Computing Astronomical Dendrograms
-Copyright (c) 2011 Thomas P. Robitaille and Braden MacDonald
+Copyright (c) 2013 Thomas P. Robitaille, Chris Beaumont, Braden MacDonald,
+                   and Erik Rosolowsky
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/astrodendro/__init__.py
+++ b/astrodendro/__init__.py
@@ -1,3 +1,5 @@
+# Licensed under an MIT open source license - see LICENSE
+
 from .dendrogram import Dendrogram
 from .analysis import ppv_catalog, pp_catalog
 from .plot import DendrogramPlotter

--- a/astrodendro/analysis.py
+++ b/astrodendro/analysis.py
@@ -1,3 +1,5 @@
+# Licensed under an MIT open source license - see LICENSE
+
 import warnings
 import numpy as np
 from astropy.units import Quantity, rad

--- a/astrodendro/dendrogram.py
+++ b/astrodendro/dendrogram.py
@@ -1,23 +1,4 @@
-# Computing Astronomical Dendrograms
-# Copyright (c) 2011-2012 Thomas P. Robitaille and Braden MacDonald
-#
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the "Software"),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# Licensed under an MIT open source license - see LICENSE
 
 # Notes:
 # - A structure is a Leaf or a Branch

--- a/astrodendro/io/__init__.py
+++ b/astrodendro/io/__init__.py
@@ -1,0 +1,1 @@
+# Licensed under an MIT open source license - see LICENSE

--- a/astrodendro/io/fits.py
+++ b/astrodendro/io/fits.py
@@ -1,23 +1,4 @@
-# Computing Astronomical Dendrograms
-# Copyright (c) 2011-2012 Thomas P. Robitaille and Braden MacDonald
-#
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the "Software"),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# Licensed under an MIT open source license - see LICENSE
 
 import numpy as np
 

--- a/astrodendro/io/hdf5.py
+++ b/astrodendro/io/hdf5.py
@@ -1,23 +1,4 @@
-# Computing Astronomical Dendrograms
-# Copyright (c) 2011-2012 Thomas P. Robitaille and Braden MacDonald
-#
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the "Software"),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# Licensed under an MIT open source license - see LICENSE
 
 import numpy as np
 

--- a/astrodendro/plot.py
+++ b/astrodendro/plot.py
@@ -1,3 +1,5 @@
+# Licensed under an MIT open source license - see LICENSE
+
 import numpy as np
 
 

--- a/astrodendro/progressbar.py
+++ b/astrodendro/progressbar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+# Licensed under an MIT open source license - see LICENSE
 """
 progressbar.py
 

--- a/astrodendro/structure.py
+++ b/astrodendro/structure.py
@@ -1,23 +1,4 @@
-# Computing Astronomical Dendrograms
-# Copyright (c) 2011-2012 Thomas P. Robitaille and Braden MacDonald
-#
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the "Software"),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# Licensed under an MIT open source license - see LICENSE
 
 import numpy as np
 

--- a/astrodendro/structure_collection.py
+++ b/astrodendro/structure_collection.py
@@ -1,3 +1,5 @@
+# Licensed under an MIT open source license - see LICENSE
+
 from matplotlib.collections import LineCollection
 
 

--- a/astrodendro/test/benchmark.py
+++ b/astrodendro/test/benchmark.py
@@ -1,23 +1,4 @@
-# Computing Astronomical Dendrograms
-# Copyright (c) 2011-2012 Thomas P. Robitaille and Braden MacDonald
-#
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the "Software"),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# Licensed under an MIT open source license - see LICENSE
 
 import timeit
 import os

--- a/astrodendro/test/test_analysis.py
+++ b/astrodendro/test/test_analysis.py
@@ -1,3 +1,5 @@
+# Licensed under an MIT open source license - see LICENSE
+
 import pytest
 from mock import patch
 

--- a/astrodendro/test/test_compute.py
+++ b/astrodendro/test/test_compute.py
@@ -1,23 +1,4 @@
-# Computing Astronomical Dendrograms
-# Copyright (c) 2011-2012 Thomas P. Robitaille and Braden MacDonald
-#
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the "Software"),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# Licensed under an MIT open source license - see LICENSE
 
 import numpy as np
 

--- a/astrodendro/test/test_index.py
+++ b/astrodendro/test/test_index.py
@@ -1,3 +1,5 @@
+# Licensed under an MIT open source license - see LICENSE
+
 import numpy as np
 from ..dendrogram import Dendrogram, TreeIndex
 

--- a/astrodendro/test/test_io.py
+++ b/astrodendro/test/test_io.py
@@ -1,23 +1,4 @@
-# Computing Astronomical Dendrograms
-# Copyright (c) 2011-2012 Thomas P. Robitaille and Braden MacDonald
-#
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the "Software"),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# Licensed under an MIT open source license - see LICENSE
 
 " Test import and export of dendrograms "
 

--- a/astrodendro/test/test_recursion.py
+++ b/astrodendro/test/test_recursion.py
@@ -1,23 +1,4 @@
-# Computing Astronomical Dendrograms
-# Copyright (c) 2011-2012 Thomas P. Robitaille and Braden MacDonald
-#
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the "Software"),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# Licensed under an MIT open source license - see LICENSE
 
 import sys
 

--- a/astrodendro/test/test_structure.py
+++ b/astrodendro/test/test_structure.py
@@ -1,3 +1,5 @@
+# Licensed under an MIT open source license - see LICENSE
+
 # The tests here ensure that the Structure class behaves as expected and has
 # the correct interface. This is done by setting up a few simple examples and
 # ensuring that all the properties and methods are behaving as expected.

--- a/astrodendro/viewer.py
+++ b/astrodendro/viewer.py
@@ -1,3 +1,5 @@
+# Licensed under an MIT open source license - see LICENSE
+
 import numpy as np
 from .plot import DendrogramPlotter
 


### PR DESCRIPTION
Is there a reason why the license text is embedded in most source files? Can we consolidate that into a top level license file, or is that illegal somehow?
