### PR TITLE
Keep discareded structures in a special attribute

### DIFF
--- a/astrodendro/dendrogram.py
+++ b/astrodendro/dendrogram.py
@@ -265,11 +265,12 @@ class Dendrogram(object):
         self.trunk = [structure for structure in structures.itervalues() if structure.parent is None]
 
         # Remove orphan leaves that aren't large enough
+        self._discarded_structures = []
         leaves_in_trunk = [structure for structure in self.trunk if structure.is_leaf]
         for leaf in leaves_in_trunk:
             if (len(leaf.values(subtree=False)) < min_npix or leaf.vmax - leaf.vmin < min_delta):
                 # This leaf is an orphan, so remove all references to it:
-                structures.pop(leaf.idx)
+                self._discarded_structures.append(structures.pop(leaf.idx))
                 self.trunk.remove(leaf)
                 leaf._fill_footprint(self.index_map, 0)
 
@@ -298,6 +299,9 @@ class Dendrogram(object):
         for s in self._structures_dict.itervalues():
             s._tree_index = ti
 
+    @property
+    def discarded_structures(self):
+        return self._discarded_structures
 
     @property
     def trunk(self):


### PR DESCRIPTION
@ChrisBeaumont - when making the tutorial movie, I found it useful to keep track of structures that are removed at the end of the tree computation. Do you think this would be ok to have in the main code?
