### PR TITLE
Internal class references on doc pages should be links

### DIFF
--- a/astrodendro/analysis.py
+++ b/astrodendro/analysis.py
@@ -345,7 +345,7 @@ class PPVStatistic(SpatialBase):
 
     Parameters
     ----------
-    structure : `~astrodendro.structure.Structure` instance
+    structure : :class:`~astrodendro.structure.Structure` instance
         The structure to compute the statistics for
     metadata : dict
          Key-value pairs of metadata
@@ -457,7 +457,7 @@ class PPStatistic(SpatialBase):
 
     Parameters
     ----------
-    structure : `~astrodendro.structure.Structure` instance
+    structure : :class:`~astrodendro.structure.Structure` instance
         The structure to compute the statistics for
     metadata : dict
          Key-value pairs of metadata

--- a/astrodendro/dendrogram.py
+++ b/astrodendro/dendrogram.py
@@ -79,7 +79,7 @@ class Dendrogram(object):
 
         Parameters
         ----------
-        data : `~numpy.ndarray`
+        data : :class:`numpy.ndarray`
             The n-dimensional array to compute the dendrogram for
         min_value : float, optional
             The minimum data value to go down to when computing the

--- a/astrodendro/flux.py
+++ b/astrodendro/flux.py
@@ -19,21 +19,21 @@ def compute_flux(input_quantities, output_unit, wavelength=None, spatial_scale=N
 
     Parameters
     ----------
-    input_quantities : `~astropy.units.quantity.Quantity` instance
-        A `~astropy.units.quantity.Quantity` instance containing an array of
+    input_quantities : :class:`~astropy.units.quantity.Quantity` instance
+        A `astropy.units.quantity.Quantity` instance containing an array of
         flux values to be summed.
-    output_unit : `~astropy.units.core.Unit` instance
+    output_unit : :class:`~astropy.units.core.Unit` instance
         The final unit to give the total flux in (should be equivalent to Jy)
-    wavelength : `~astropy.units.quantity.Quantity` instance
+    wavelength : :class:`~astropy.units.quantity.Quantity` instance
         The wavelength of the data (required if converting e.g.
         ergs/cm^2/s/micron to Jy)
-    spatial_scale : `~astropy.units.quantity.Quantity` instance
+    spatial_scale : :class:`~astropy.units.quantity.Quantity` instance
         The pixel scale of the data (should be an angle)
-    velocity_scale : `~astropy.units.quantity.Quantity` instance
+    velocity_scale : :class:`~astropy.units.quantity.Quantity` instance
         The pixel scale of the data (should be a velocity)
-    beam_major : `~astropy.units.quantity.Quantity` instance
+    beam_major : :class:`~astropy.units.quantity.Quantity` instance
         The beam major full width at half_maximum (FWHM)
-    beam_minor : `~astropy.units.quantity.Quantity` instance
+    beam_minor : :class:`~astropy.units.quantity.Quantity` instance
         The beam minor full width at half_maximum (FWHM)
     """
 

--- a/astrodendro/plot.py
+++ b/astrodendro/plot.py
@@ -81,7 +81,7 @@ class DendrogramPlotter(object):
 
         Parameters
         ----------
-        ax : `matplotlib.axes.Axes` instance
+        ax : :class:`~matplotlib.axes.Axes` instance
             The Axes inside which to plot the dendrogram
         structure : int or `~astrodendro.structure.Structure`, optional
             If specified, only plot this structure. This can be either the
@@ -117,7 +117,7 @@ class DendrogramPlotter(object):
 
         Parameters
         ----------
-        ax : `matplotlib.axes.Axes` instance
+        ax : :class:`~matplotlib.axes.Axes` instance
             The Axes inside which to plot the dendrogram
         structure : int or `~astrodendro.structure.Structure`, optional
             If specified, only plot this structure. This can be either the
@@ -164,12 +164,12 @@ class DendrogramPlotter(object):
 
         Parameters
         ----------
-        structure : `~astrodendro.structure.Structure`
+        structure : :class:`~astrodendro.structure.Structure`
             The structure to plot. If not set, the whole tree will be plotted.
 
         Returns
         -------
-        lines : `astrodendro.plot.StructureCollection`
+        lines : :class:`~astrodendro.plot.StructureCollection`
             The lines (sub-class of LineCollection) which can be directly used in Matplotlib
 
         Notes

--- a/astrodendro/structure.py
+++ b/astrodendro/structure.py
@@ -283,7 +283,7 @@ class Structure(object):
 
         Parameters
         ----------
-        array : `~numpy.ndarray`
+        array : :class:`~numpy.ndarray`
             The array to write the footprint to
         recursive : bool
             Whether to also add the footprint for the sub-structures
@@ -470,7 +470,7 @@ class Structure(object):
 
         Returns
         -------
-        mask : `~numpy.ndarray`
+        mask : :class:`~numpy.ndarray`
             The mask outlining the structure (``False`` values are used outside
             the structure, and ``True`` values inside).
         """


### PR DESCRIPTION
Search, e.g., for tildes on http://dendrograms.readthedocs.org/en/latest/api/astrodendro.plot.DendrogramPlotter.html 

Things like ~astrodendro.structure.Structure should be links, correct?
