### PR TITLE
Fixing literal edge cases

### DIFF
--- a/astrodendro/analysis.py
+++ b/astrodendro/analysis.py
@@ -293,6 +293,10 @@ class SpatialBase(object):
     def _world_pos(self):
         try:
             xyz = list(np.array(self.stat.mom1()) % np.array(self.metadata['shape_tuple']))[::-1]
+            # wcs complains if px exceeds data, so make it negative if it falls between shp-1 and shp
+            for i, shp in zip(range(len(xyz)), self.metadata['shape_tuple'][::-1]):
+                if xyz[i] > shp-1:
+                    xyz[i] -= shp
         except (TypeError, AttributeError, KeyError):
             xyz = self.stat.mom1()[::-1]
 

--- a/astrodendro/tests/test_analysis.py
+++ b/astrodendro/tests/test_analysis.py
@@ -433,7 +433,7 @@ def test_wraparound_catalog():
     assert catalog_centered['radius'][0] == catalog_straddling['radius'][0]
     assert catalog_centered['area_exact'][0] == catalog_straddling['area_exact'][0]
 
-    assert (catalog_centered['x_cen'][0] + 4) % (x_centered.shape[1]-1) == catalog_straddling['x_cen'][0] # offset by 4 px, then wrapped around
+    assert (catalog_centered['x_cen'][0] + 4) % (x_centered.shape[1]) == catalog_straddling['x_cen'][0] # offset by 4 px, then wrapped around
     assert catalog_centered['y_cen'][0] == catalog_straddling['y_cen'][0]
 
     # default behavior is to NOT join structures on data edges, let's make sure that we aren't fooling ourselves.


### PR DESCRIPTION
I added a complicated line of logic to `SpatialBase._world_pos` that tries to modulo the `mom1` values by the data shape tuple (minus 1), and if it can't, it falls back to the original behavior and signature. I piggybacked `shape_tuple` into `metadata` when `_make_catalog` is called, which might be a little too clever of me since `metadata` is otherwise only used for user-defined parameters.

Those caveats aside, this completely fixes #122 for me -- all of my catalog properties are no longer `nan` and everything seems well-behaved, including the test case that I had to update (because it is now properly wrapping the `x_cen` values, as opposed to before, when it would let the `x_cen` value "spill over" to values higher than the data indices).

Is this acceptable to merge? I could write more test cases, especially since @ChrisBeaumont has suggested I focus more on unit tests rather than integration tests, in our conversation at #123. 
