### PR TITLE
plot_tree should accept singular structure

### DIFF
--- a/astrodendro/plot.py
+++ b/astrodendro/plot.py
@@ -191,7 +191,7 @@ class DendrogramPlotter(object):
         # Case 2: one structure is selected, and subtree is True
         else:
             if subtree:
-                if isinstance(strucutres, int):
+                if isinstance(structures, int):
                     structure = self.dendrogram[structures]
                 elif isinstance(structures, Structure):
                     structure = structures


### PR DESCRIPTION
fix bug introduced in 4c5a6432be45b9878b1df84ba38aa4186ca6712b:
'structures' can be an int (since plot_tree accepts singular 'structure'
which intuitively should be an int)
