### PR TITLE
Short fix to Lasso selection in Scatter, for partially `nan`'d columns

### DIFF
--- a/astrodendro/scatter.py
+++ b/astrodendro/scatter.py
@@ -87,7 +87,10 @@ class Scatter(object):
         def callback(verts):
             p = path.Path(verts)
 
-            indices = np.where(p.contains_points(self.xys))[0]
+            # `p.contains_points` has undesirable behavior that makes it necessary to explicitly exclude `nan` data.
+            indices = np.where(p.contains_points(self.xys) & 
+                               ~np.isnan(self.xdata) & 
+                               ~np.isnan(self.ydata))[0]
             selected_structures = [self.dendrogram[i] for i in indices]
 
             if len(selected_structures) == 0:


### PR DESCRIPTION
I encountered weird behavior in Scatter when using Lasso select: when I put in catalog data in which either the x or y column (but not both simultaneously) had a few "nan" datapoints, then some incorrect selections would occur when I drew lassos around these data.

I investigated further, and discovered that `matplotlib.path.Path.contains_points()` actually seems to be at fault here, in that it does the wrong thing: if there are data tuples that are (nan, y) or (x, nan), and "y" or "x" are in the selected lasso range, then those rows get selected. (For example, if you draw a unit circle around the origin, and a row of data has (0, nan), it gets selected by this lasso, although (2, nan) does not.)

The specified pull request is a short fix to this. I've tested it out in production and it appears to do the right thing.
