### PR TITLE
Include scipy in some Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
 matrix:
     include:
         - python: 2.7
-          env: NP_VER=1.7 ASTRO_VER=0.4
+          env: NP_VER=1.7 ASTRO_VER=0.3
         - python: 2.7
           env: NP_VER=1.6 ASTRO_VER=0.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,15 +16,17 @@ env:
         - PYTEST_ARGS='--cov astrodendro'
         - CONDA_BASE='pip setuptools h5py pytest matplotlib cython jinja2'
         - PIP_BASE='pytest-cov coveralls mock'
+        - CONDA_ADDITIONAL=''
     matrix:
-        - NP_VER=1.9 ASTRO_VER=0.4
-        - NP_VER=1.8 ASTRO_VER=0.3
+        - NP_VER=1.9 ASTRO_VER=1.0 CONDA_ADDITIONAL=scipy
+        - NP_VER=1.9 ASTRO_VER=1.0
+        - NP_VER=1.8 ASTRO_VER=0.4
         - NP_VER=1.9 ASTRO_VER=dev
 
 matrix:
     include:
         - python: 2.7
-          env: NP_VER=1.7 ASTRO_VER=0.3
+          env: NP_VER=1.7 ASTRO_VER=0.4
         - python: 2.7
           env: NP_VER=1.6 ASTRO_VER=0.3
 
@@ -42,7 +44,7 @@ before_install:
     - source activate test
 
     # DEPENDENCIES
-    - $CONDA_INSTALL $CONDA_BASE numpy=$NP_VER
+    - $CONDA_INSTALL $CONDA_BASE numpy=$NP_VER $CONDA_ADDITIONAL
     - $PIP_INSTALL $PIP_BASE
     - if [[ $ASTRO_VER == dev ]]; then pip install -e git+git://github.com/astropy/astropy.git#egg=astropy; else $CONDA_INSTALL astropy=$ASTRO_VER numpy=$NP_VER; fi
 

--- a/astrodendro/io/util.py
+++ b/astrodendro/io/util.py
@@ -140,6 +140,11 @@ def _fast_reader(index_map, data):
 
     # ndimage ignores 0 and -1, but we want index 0
     object_slices = ndimage.find_objects(index_map+1)
+
+    # find_objects returns a tuple that includes many None values that we
+    # need to get rid of.
+    object_slices = [x for x in object_slices if x is not None]
+
     index_cube = np.indices(index_map.shape)
 
     # Need to have same length, otherwise assumptions above are wrong

--- a/astrodendro/io/util.py
+++ b/astrodendro/io/util.py
@@ -151,7 +151,8 @@ def _fast_reader(index_map, data):
     assert len(idxs) == len(object_slices)
     log.debug('Creating index maps for {0} indices...'.format(len(idxs)))
 
-    for idx,sl in ProgressBar(zip(idxs, object_slices)):
+    p = ProgressBar(len(object_slices))
+    for idx,sl in zip(idxs, object_slices):
         match = index_map[sl] == idx
         sl2 = (slice(None),) + sl
         match_inds = index_cube[sl2][:, match]
@@ -159,6 +160,7 @@ def _fast_reader(index_map, data):
         dd = data[sl][match].tolist()
         flux_by_structure[idx] = dd
         indices_by_structure[idx] = coords
+        p.update()
 
     return flux_by_structure, indices_by_structure
 

--- a/astrodendro/tests/test_recursion.py
+++ b/astrodendro/tests/test_recursion.py
@@ -64,7 +64,7 @@ class TestRecursionLimit(object):
     def test_plot(self):
         sys.setrecursionlimit(self._oldlimit)
         ax = plt.gca()
-        sys.setrecursionlimit(100)
+        sys.setrecursionlimit(110)
 
         d = Dendrogram.compute(self.data)
         p = d.plotter()


### PR DESCRIPTION
I think there are some failures in ``_fast_reader`` that weren't being caught by Travis because scipy wasn't installed.