### PR TITLE
Cast newick string out of bytes on python3

### DIFF
--- a/astrodendro/io/util.py
+++ b/astrodendro/io/util.py
@@ -6,7 +6,8 @@ from astropy import log
 
 
 def parse_newick(string):
-
+    string = string.decode('utf8')
+    
     items = {}
 
     # Find maximum level


### PR DESCRIPTION
When loading HDF5 files, python 3 (at least in some instances) loads the newick string as a "bytes" object, which breaks the string comparisons in the parse_newick function. This PR coerces the input into a string type.
