### PR TITLE
Correct an error in analysis.py: sqrt(mom2) is not FWHM

### DIFF
--- a/astrodendro/analysis.py
+++ b/astrodendro/analysis.py
@@ -282,8 +282,8 @@ class SpatialBase(object):
 
     wavelength = MetadataQuantity('wavelength', 'Wavelength')
     spatial_scale = MetadataQuantity('spatial_scale', 'Pixel width/height')
-    beam_major = MetadataQuantity('beam_major', 'Major FWHM of beam')
-    beam_minor = MetadataQuantity('beam_minor', 'Minor FWHM of beam')
+    beam_major = MetadataQuantity('beam_major', 'Major axis (sigma) of beam')
+    beam_minor = MetadataQuantity('beam_minor', 'Minor axis (sigma) of beam')
     data_unit = MetadataQuantity('data_unit', 'Units of the pixel values', strict=True)
     wcs = MetadataWCS('wcs', 'WCS object')
 


### PR DESCRIPTION
The object creation lines say that the major/minor axes are FWHM, but they are not.  They are `sqrt(moment2)`, which is `sigma` of a gaussian, not the FWHM of a gaussian.