### PR TITLE
IO optimization

### DIFF
--- a/astrodendro/io/util.py
+++ b/astrodendro/io/util.py
@@ -22,7 +22,7 @@ def parse_newick(string):
 
     # Loop through levels and construct tree
     log.debug('Tree loading...')
-    for level in range(max_level, 0, -1):
+    for level in ProgressBar(range(max_level, 0, -1)):
 
         pairs = []
 

--- a/astrodendro/structure.py
+++ b/astrodendro/structure.py
@@ -69,7 +69,7 @@ class Structure(object):
             self._indices = [indices]
             self._values = [values]
             self._vmin, self._vmax = values, values
-        elif isinstance(indices, list) and isinstance(values, list):
+        elif (isinstance(indices, list) or isinstance(indices, np.ndarray)) and isinstance(values, list):
             self._indices = indices
             self._values = values
             self._vmin, self._vmax = min(values), max(values)
@@ -78,7 +78,10 @@ class Structure(object):
             self._values = [x for x in values]
             self._vmin, self._vmax = min(values), max(values)
 
-        self._smallest_index = min(self._indices)
+        try:
+            self._smallest_index = min(self._indices)
+        except ValueError:
+            self._smallest_index = self._indices[0]
 
         self.idx = idx
 
@@ -402,8 +405,7 @@ class Structure(object):
 
         if self._peak is None:
             for s in reversed(list(prefix_visit(self))):
-                s._peak = (s._indices[s._values.index(s.vmax)],
-                          s.vmax)
+                s._peak = (tuple(s._indices[s._values.index(s.vmax)]), s.vmax)
                 if s.is_leaf:
                     s._peak_subtree = s._peak
                 else:


### PR DESCRIPTION
This is a WIP to speed up the reading and parsing of dendrograms from disk.

One key change in speeding up the parsing was removing a conversion from an array of coordinates to a list of tuples of coordinates.  Creating N tuples was a very expensive step, apparently, and eliminating it cut the time by >50% in the `_fast_reader`.

The WIP is (1) to make sure that we didn't break anything, really and (2) to try to speed up `parse_newick`.