### PR TITLE
Fix use of subtree parameter in plot_tree and get_mask

### DIFF
--- a/astrodendro/plot.py
+++ b/astrodendro/plot.py
@@ -100,7 +100,7 @@ class DendrogramPlotter(object):
         """
 
         # Get the lines for the dendrogram
-        lines = self.get_lines(structures=structure, **kwargs)
+        lines = self.get_lines(structures=structure, subtree=subtree, **kwargs)
 
         # Add the lines to the axes
         ax.add_collection(lines)

--- a/astrodendro/structure.py
+++ b/astrodendro/structure.py
@@ -477,7 +477,7 @@ class Structure(object):
         """
         if shape is None:
             shape = self._dendrogram.data.shape
-        indices = self.indices(subtree=True) if subtree else self.indices
+        indices = self.indices(subtree=True) if subtree else self.indices()
         mask = np.zeros(shape, dtype=bool)
         mask[indices] = True
         return mask


### PR DESCRIPTION
This change seems needed to allow custom coloring of the dendrogram subtrees. My main use case is using different colors for trunks, branches, and leaves, but I also use subtree=False to color the structures according to a property like line width or virial parameter.

(This is from a previous pull request that got corrupted, so I have cleaned it up.)