### PR TITLE
WCSAxes import fix

### DIFF
--- a/astrodendro/viewer.py
+++ b/astrodendro/viewer.py
@@ -60,6 +60,7 @@ class SelectionHub(object):
 class BasicDendrogramViewer(object):
 
     def __init__(self, dendrogram):
+
         if dendrogram.data.ndim not in [2, 3]:
             raise ValueError(
                 "Only 2- and 3-dimensional arrays are supported at this time")
@@ -83,6 +84,7 @@ class BasicDendrogramViewer(object):
         # Initiate plot
         import matplotlib.pyplot as plt
         self.fig = plt.figure(figsize=(14, 8))
+
         ax_image_limits = [0.1, 0.1, 0.4, 0.7]
 
         try:
@@ -92,6 +94,7 @@ class BasicDendrogramViewer(object):
             __wcaxes_imported = False
             if self.dendrogram.wcs is not None:
                 warnings.warn("`WCSAxes` package required for wcs coordinate display.")
+
         if self.dendrogram.wcs is not None and __wcaxes_imported:
 
             if self.array.ndim == 2:

--- a/astrodendro/viewer.py
+++ b/astrodendro/viewer.py
@@ -87,23 +87,14 @@ class BasicDendrogramViewer(object):
 
         ax_image_limits = [0.1, 0.1, 0.4, 0.7]
 
-        try:
-            from astropy.visualization.wcsaxes import WCSAxes
-            __wcaxes_imported = True
-        except ImportError:
-            __wcaxes_imported = False
-            if self.dendrogram.wcs is not None:
-                warnings.warn("`WCSAxes` package required for wcs coordinate display.")
-
-        if self.dendrogram.wcs is not None and __wcaxes_imported:
+        if self.dendrogram.wcs is not None:
 
             if self.array.ndim == 2:
                 slices = ('x', 'y')
             else:
                 slices = ('x', 'y', 1)
 
-            ax_image = WCSAxes(self.fig, ax_image_limits, wcs=self.dendrogram.wcs, slices=slices)
-            self.ax_image = self.fig.add_axes(ax_image)
+            self.ax_image = self.fig.add_axes(ax_image_limits, projection=self.dendrogram.wcs, slices=slices)
 
         else:
             self.ax_image = self.fig.add_axes(ax_image_limits)

--- a/astrodendro/viewer.py
+++ b/astrodendro/viewer.py
@@ -60,7 +60,6 @@ class SelectionHub(object):
 class BasicDendrogramViewer(object):
 
     def __init__(self, dendrogram):
-
         if dendrogram.data.ndim not in [2, 3]:
             raise ValueError(
                 "Only 2- and 3-dimensional arrays are supported at this time")
@@ -84,17 +83,15 @@ class BasicDendrogramViewer(object):
         # Initiate plot
         import matplotlib.pyplot as plt
         self.fig = plt.figure(figsize=(14, 8))
-
         ax_image_limits = [0.1, 0.1, 0.4, 0.7]
 
         try:
-            from wcsaxes import WCSAxes
+            from astropy.visualization.wcsaxes import WCSAxes
             __wcaxes_imported = True
         except ImportError:
             __wcaxes_imported = False
             if self.dendrogram.wcs is not None:
                 warnings.warn("`WCSAxes` package required for wcs coordinate display.")
-
         if self.dendrogram.wcs is not None and __wcaxes_imported:
 
             if self.array.ndim == 2:


### PR DESCRIPTION
Imports WCSAxes from astropy.visualizer.wcs.WCSAxes instead of the standalone package for dendrogram viewer.